### PR TITLE
Display proper data size in tape browser

### DIFF
--- a/tape.c
+++ b/tape.c
@@ -992,15 +992,17 @@ tape_block_details( char *buffer, size_t length,
     break;
 
   normal:
+    /* The -2 here is for the flag and parity bytes */
     snprintf( buffer, length, "%lu bytes",
-	      (unsigned long)libspectrum_tape_block_data_length( block ) );
+          (unsigned long)libspectrum_tape_block_data_length( block ) - 2 );
     break;
 
   case LIBSPECTRUM_TAPE_BLOCK_TURBO:
   case LIBSPECTRUM_TAPE_BLOCK_PURE_DATA:
   case LIBSPECTRUM_TAPE_BLOCK_RAW_DATA:
+    /* The -2 here is for the flag and parity bytes */
     snprintf( buffer, length, "%lu bytes",
-	      (unsigned long)libspectrum_tape_block_data_length( block ) );
+          (unsigned long)libspectrum_tape_block_data_length( block ) - 2 );
     break;
 
   case LIBSPECTRUM_TAPE_BLOCK_PURE_TONE:


### PR DESCRIPTION
Fixes https://github.com/speccytools/fuse-for-macosx/issues/9

Subtract 2 from the block size for TAP and TZX files.

Before:
<img width="381" height="417" alt="tzx-fuse" src="https://github.com/user-attachments/assets/8fdf407b-cd3d-44da-a924-997efc75270b" />

After:
<img width="381" height="417" alt="fixed" src="https://github.com/user-attachments/assets/a944d0fc-e5ab-45d9-a6a1-1c88f042d611" />

For reference, I tested a few other tools with a [Monty on the Run](https://worldofspectrum.net/item/0003258/) TZX. 

SpecEmu and ZEsarUX ([source](https://github.com/chernandezba/zesarux/blob/c4b46e30f517220b80bf3090f31f99adfe5bb208/src/utils.c#L14088)) also display the data size.
<img width="431" height="248" alt="tzx-specemu" src="https://github.com/user-attachments/assets/2854066b-9283-4708-b347-7532df6a7957" />
<img width="513" height="352" alt="tzx-ZEsarUX" src="https://github.com/user-attachments/assets/4942f4f7-c06b-4c6a-9c0c-98a3b2c61f25" />

But Tapir (which is a tape editor, not an emulator) displays the block size: 
<img width="595" height="493" alt="tzx-tapir" src="https://github.com/user-attachments/assets/5dc1dd85-ba99-4cf1-a50e-99790e57dd83" />

Spectaculator (which is a quite mature emulator) subtracts 2 for the TAP blocks but not for the TZX ones 🤷‍♂️  I believe the latter is just a bug.

![](https://www.spectaculator.com/wp-content/uploads/2013/07/noautoload.png)