### PR TITLE
Fix: Text turns black in dark mode after clicking form fields

### DIFF
--- a/fusepb/controllers/LoadBinaryController.h
+++ b/fusepb/controllers/LoadBinaryController.h
@@ -27,9 +27,9 @@
 
 @interface LoadBinaryController : NSWindowController
 {
-  IBOutlet NSFormCell *file;
-  IBOutlet NSFormCell *start;
-  IBOutlet NSFormCell *length;
+  IBOutlet NSTextField *file;
+  IBOutlet NSTextField *start;
+  IBOutlet NSTextField *length;
   IBOutlet NSButton *apply;
 }
 

--- a/fusepb/controllers/PokeFinderController.h
+++ b/fusepb/controllers/PokeFinderController.h
@@ -27,8 +27,8 @@
 
 @interface PokeFinderController : NSWindowController
 {
-  IBOutlet NSFormCell *searchFor;
-  IBOutlet NSFormCell *locations;
+  IBOutlet NSTextField *searchFor;
+  IBOutlet NSTextField *locations;
   IBOutlet NSTableView *matchList;
   NSMutableArray *tableContents;
 }

--- a/fusepb/controllers/PreferencesController.h
+++ b/fusepb/controllers/PreferencesController.h
@@ -29,10 +29,10 @@
 
 @interface PreferencesController : NSWindowController
 {
-  IBOutlet NSFormCell *rom0Filename;
-  IBOutlet NSFormCell *rom1Filename;
-  IBOutlet NSFormCell *rom2Filename;
-  IBOutlet NSFormCell *rom3Filename;
+  IBOutlet NSTextField *rom0Filename;
+  IBOutlet NSTextField *rom1Filename;
+  IBOutlet NSTextField *rom2Filename;
+  IBOutlet NSTextField *rom3Filename;
   IBOutlet NSArrayController *machineRomsController;
   IBOutlet NSMatrix *massStorageType;
   IBOutlet NSMatrix *externalSoundType;

--- a/fusepb/controllers/SaveBinaryController.h
+++ b/fusepb/controllers/SaveBinaryController.h
@@ -28,9 +28,9 @@
 @interface SaveBinaryController : NSWindowController
 {
     IBOutlet NSButton *apply;
-    IBOutlet NSFormCell *file;
-    IBOutlet NSFormCell *length;
-    IBOutlet NSFormCell *start;
+    IBOutlet NSTextField *file;
+    IBOutlet NSTextField *length;
+    IBOutlet NSTextField *start;
 }
 
 - (IBAction)apply:(id)sender;

--- a/fusepb/xibs/LoadBinary.xib
+++ b/fusepb/xibs/LoadBinary.xib
@@ -26,40 +26,57 @@
                 <rect key="frame" x="0.0" y="0.0" width="591" height="162"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <form verticalHuggingPriority="750" mode="track" allowsEmptySelection="NO" autosizesCells="NO" id="14">
-                        <rect key="frame" x="33" y="60" width="173" height="52"/>
+                    <textField verticalHuggingPriority="750" id="lbl-start">
+                        <rect key="frame" x="33" y="90" width="42" height="22"/>
                         <autoresizingMask key="autoresizingMask"/>
-                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                        <size key="cellSize" width="173" height="22"/>
-                        <size key="intercellSpacing" width="1" height="8"/>
-                        <formCell key="prototype" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" alignment="justified" title="Field:" id="46">
+                        <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="Start:" id="lbl-start-cell">
                             <font key="font" metaFont="system"/>
-                            <font key="titleFont" metaFont="system"/>
-                        </formCell>
-                        <cells>
-                            <column>
-                                <formCell scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" alignment="justified" title="Start:" id="16">
-                                    <numberFormatter key="formatter" formatterBehavior="default10_4" usesGroupingSeparator="NO" groupingSize="0" minimumIntegerDigits="0" maximumIntegerDigits="42" id="48" customClass="NumberFormatter">
-                                        <real key="minimum" value="0.0"/>
-                                        <real key="maximum" value="65535"/>
-                                    </numberFormatter>
-                                    <font key="font" metaFont="system"/>
-                                    <font key="titleFont" metaFont="system"/>
-                                </formCell>
-                                <formCell scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" alignment="justified" tag="1" title="Length:" id="17">
-                                    <numberFormatter key="formatter" formatterBehavior="default10_4" usesGroupingSeparator="NO" groupingSize="0" minimumIntegerDigits="0" maximumIntegerDigits="42" id="49" customClass="NumberFormatter">
-                                        <real key="minimum" value="1"/>
-                                        <real key="maximum" value="65535"/>
-                                    </numberFormatter>
-                                    <font key="font" metaFont="system"/>
-                                    <font key="titleFont" metaFont="system"/>
-                                </formCell>
-                            </column>
-                        </cells>
+                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                    </textField>
+                    <textField verticalHuggingPriority="750" id="16">
+                        <rect key="frame" x="79" y="90" width="127" height="22"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" alignment="left" id="16-cell">
+                            <numberFormatter key="formatter" formatterBehavior="default10_4" usesGroupingSeparator="NO" groupingSize="0" minimumIntegerDigits="0" maximumIntegerDigits="42" id="48" customClass="NumberFormatter">
+                                <real key="minimum" value="0.0"/>
+                                <real key="maximum" value="65535"/>
+                            </numberFormatter>
+                            <font key="font" metaFont="system"/>
+                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
                         <connections>
                             <outlet property="delegate" destination="-2" id="38"/>
+                            <outlet property="nextKeyView" destination="17" id="16-nkv"/>
                         </connections>
-                    </form>
+                    </textField>
+                    <textField verticalHuggingPriority="750" id="lbl-length">
+                        <rect key="frame" x="33" y="60" width="55" height="22"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                        <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="Length:" id="lbl-length-cell">
+                            <font key="font" metaFont="system"/>
+                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                    </textField>
+                    <textField verticalHuggingPriority="750" id="17">
+                        <rect key="frame" x="92" y="60" width="114" height="22"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" alignment="left" id="17-cell">
+                            <numberFormatter key="formatter" formatterBehavior="default10_4" usesGroupingSeparator="NO" groupingSize="0" minimumIntegerDigits="0" maximumIntegerDigits="42" id="49" customClass="NumberFormatter">
+                                <real key="minimum" value="1"/>
+                                <real key="maximum" value="65535"/>
+                            </numberFormatter>
+                            <font key="font" metaFont="system"/>
+                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                        <connections>
+                            <outlet property="delegate" destination="-2" id="38b"/>
+                        </connections>
+                    </textField>
                     <button verticalHuggingPriority="750" id="19">
                         <rect key="frame" x="409" y="12" width="84" height="32"/>
                         <autoresizingMask key="autoresizingMask"/>
@@ -96,29 +113,28 @@ DQ
                             <action selector="chooseFile:" target="-2" id="33"/>
                         </connections>
                     </button>
-                    <form verticalHuggingPriority="750" mode="track" allowsEmptySelection="NO" autosizesCells="NO" id="24">
-                        <rect key="frame" x="20" y="120" width="455" height="22"/>
+                    <textField verticalHuggingPriority="750" id="lbl-file">
+                        <rect key="frame" x="20" y="120" width="65" height="22"/>
                         <autoresizingMask key="autoresizingMask"/>
-                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                        <size key="cellSize" width="455" height="22"/>
-                        <size key="intercellSpacing" width="1" height="8"/>
-                        <formCell key="prototype" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" alignment="justified" title="Field:" id="47">
+                        <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="Filename:" id="lbl-file-cell">
                             <font key="font" metaFont="system"/>
-                            <font key="titleFont" metaFont="system"/>
-                        </formCell>
-                        <cells>
-                            <column>
-                                <formCell scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" alignment="justified" title="Filename:" id="25">
-                                    <font key="font" metaFont="system"/>
-                                    <font key="titleFont" metaFont="system"/>
-                                </formCell>
-                            </column>
-                        </cells>
+                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                    </textField>
+                    <textField verticalHuggingPriority="750" id="25">
+                        <rect key="frame" x="89" y="120" width="386" height="22"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" alignment="left" id="25-cell">
+                            <font key="font" metaFont="system"/>
+                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
                         <connections>
                             <outlet property="delegate" destination="-2" id="37"/>
-                            <outlet property="nextKeyView" destination="14" id="41"/>
+                            <outlet property="nextKeyView" destination="16" id="41"/>
                         </connections>
-                    </form>
+                    </textField>
                 </subviews>
             </view>
             <connections>

--- a/fusepb/xibs/PokeFinder.xib
+++ b/fusepb/xibs/PokeFinder.xib
@@ -61,7 +61,7 @@ DQ
                         </buttonCell>
                         <connections>
                             <action selector="apply:" target="-2" id="26"/>
-                            <outlet property="nextKeyView" destination="14" id="38"/>
+                            <outlet property="nextKeyView" destination="21" id="38"/>
                         </connections>
                     </button>
                     <scrollView horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" id="12">
@@ -128,36 +128,50 @@ DQ
                             <outlet property="nextKeyView" destination="7" id="35"/>
                         </connections>
                     </scrollView>
-                    <form verticalHuggingPriority="750" mode="track" allowsEmptySelection="NO" autosizesCells="NO" id="14">
-                        <rect key="frame" x="22" y="257" width="222" height="52"/>
+                    <textField verticalHuggingPriority="750" id="lbl-searchfor">
+                        <rect key="frame" x="22" y="287" width="80" height="22"/>
                         <autoresizingMask key="autoresizingMask"/>
-                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                        <size key="cellSize" width="222" height="22"/>
-                        <size key="intercellSpacing" width="1" height="8"/>
-                        <formCell key="prototype" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" alignment="justified" title="Field:" id="49">
+                        <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="Search for:" id="lbl-searchfor-cell">
                             <font key="font" metaFont="system"/>
-                            <font key="titleFont" metaFont="system"/>
-                        </formCell>
-                        <cells>
-                            <column>
-                                <formCell scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" borderStyle="bezel" alignment="justified" title="Search for:" id="21">
-                                    <numberFormatter key="formatter" formatterBehavior="default10_4" usesGroupingSeparator="NO" groupingSize="0" minimumIntegerDigits="0" maximumIntegerDigits="42" id="55" customClass="NumberFormatter"/>
-                                    <font key="font" metaFont="system"/>
-                                    <font key="titleFont" metaFont="system"/>
-                                    <connections>
-                                        <action selector="search:" target="-2" id="33"/>
-                                    </connections>
-                                </formCell>
-                                <formCell scrollable="YES" lineBreakMode="clipping" selectable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" alignment="justified" tag="1" title="Possible locations:" id="22">
-                                    <font key="font" metaFont="system"/>
-                                    <font key="titleFont" metaFont="system"/>
-                                </formCell>
-                            </column>
-                        </cells>
+                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                    </textField>
+                    <textField verticalHuggingPriority="750" id="21">
+                        <rect key="frame" x="106" y="287" width="138" height="22"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" borderStyle="bezel" alignment="left" id="21-cell">
+                            <numberFormatter key="formatter" formatterBehavior="default10_4" usesGroupingSeparator="NO" groupingSize="0" minimumIntegerDigits="0" maximumIntegerDigits="42" id="55" customClass="NumberFormatter"/>
+                            <font key="font" metaFont="system"/>
+                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                        <connections>
+                            <action selector="search:" target="-2" id="33"/>
+                            <outlet property="nextKeyView" destination="22" id="21-nkv"/>
+                        </connections>
+                    </textField>
+                    <textField verticalHuggingPriority="750" id="lbl-locations">
+                        <rect key="frame" x="22" y="257" width="115" height="22"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                        <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="Possible locations:" id="lbl-locations-cell">
+                            <font key="font" metaFont="system"/>
+                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                    </textField>
+                    <textField verticalHuggingPriority="750" id="22">
+                        <rect key="frame" x="141" y="257" width="103" height="22"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" alignment="left" id="22-cell">
+                            <font key="font" metaFont="system"/>
+                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
                         <connections>
                             <outlet property="nextKeyView" destination="10" id="34"/>
                         </connections>
-                    </form>
+                    </textField>
                     <button verticalHuggingPriority="750" id="39">
                         <rect key="frame" x="16" y="44" width="124" height="32"/>
                         <autoresizingMask key="autoresizingMask"/>

--- a/fusepb/xibs/Preferences.xib
+++ b/fusepb/xibs/Preferences.xib
@@ -972,33 +972,32 @@
                                     <binding destination="270" name="value" keyPath="values.zxataspwriteprotect" id="a1q-3d-peT"/>
                                 </connections>
                             </button>
-                            <form verticalHuggingPriority="750" fixedFrame="YES" mode="track" allowsEmptySelection="NO" autorecalculatesCellSize="YES" translatesAutoresizingMaskIntoConstraints="NO" id="pgI-Qm-62i">
-                                <rect key="frame" x="20" y="97" width="243" height="22"/>
+                            <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="lbl-mdrlen">
+                                <rect key="frame" x="20" y="97" width="125" height="22"/>
                                 <autoresizingMask key="autoresizingMask"/>
-                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                <size key="cellSize" width="243" height="22"/>
-                                <size key="intercellSpacing" width="1" height="8"/>
-                                <formCell key="prototype" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" alignment="justified" title="Field:" id="kS6-1D-SfM">
+                                <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="MDR cartridge len:" id="lbl-mdrlen-cell">
                                     <font key="font" metaFont="system"/>
-                                    <font key="titleFont" metaFont="system"/>
-                                </formCell>
-                                <cells>
-                                    <column>
-                                        <formCell scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="justified" title="MDR cartridge len:" id="H7r-3H-Vna">
-                                            <numberFormatter key="formatter" formatterBehavior="custom10_4" positiveFormat="#" negativeFormat="#" usesGroupingSeparator="NO" paddingCharacter="*" groupingSize="0" minimumIntegerDigits="0" maximumIntegerDigits="3" decimalSeparator="." groupingSeparator="," currencyDecimalSeparator="." plusSign="+" minusSign="-" notANumberSymbol="NaN" perMillSymbol="‰" percentSymbol="%" exponentSymbol="E" positivePrefix="" positiveSuffix="" negativePrefix="-" negativeSuffix="" id="cMb-uh-8m6" customClass="NumberFormatter">
-                                                <nil key="negativeInfinitySymbol"/>
-                                                <nil key="positiveInfinitySymbol"/>
-                                                <real key="minimum" value="1"/>
-                                            </numberFormatter>
-                                            <font key="font" metaFont="system"/>
-                                            <font key="titleFont" metaFont="system"/>
-                                            <connections>
-                                                <binding destination="270" name="value" keyPath="values.mdrlen" id="7U6-X7-kbF"/>
-                                            </connections>
-                                        </formCell>
-                                    </column>
-                                </cells>
-                            </form>
+                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                            </textField>
+                            <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="fld-mdrlen">
+                                <rect key="frame" x="149" y="97" width="114" height="22"/>
+                                <autoresizingMask key="autoresizingMask"/>
+                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" alignment="left" id="fld-mdrlen-cell">
+                                    <numberFormatter key="formatter" formatterBehavior="custom10_4" positiveFormat="#" negativeFormat="#" usesGroupingSeparator="NO" paddingCharacter="*" groupingSize="0" minimumIntegerDigits="0" maximumIntegerDigits="3" decimalSeparator="." groupingSeparator="," currencyDecimalSeparator="." plusSign="+" minusSign="-" notANumberSymbol="NaN" perMillSymbol="‰" percentSymbol="%" exponentSymbol="E" positivePrefix="" positiveSuffix="" negativePrefix="-" negativeSuffix="" id="cMb-uh-8m6" customClass="NumberFormatter">
+                                        <nil key="negativeInfinitySymbol"/>
+                                        <nil key="positiveInfinitySymbol"/>
+                                        <real key="minimum" value="1"/>
+                                    </numberFormatter>
+                                    <font key="font" metaFont="system"/>
+                                    <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                                <connections>
+                                    <binding destination="270" name="value" keyPath="values.mdrlen" id="7U6-X7-kbF"/>
+                                </connections>
+                            </textField>
                         </subviews>
                     </view>
                 </box>
@@ -1477,69 +1476,6 @@
                         <autoresizingMask key="autoresizingMask"/>
                     </tableHeaderView>
                 </scrollView>
-                <button tag="2" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1598">
-                    <rect key="frame" x="311" y="395" width="77" height="28"/>
-                    <autoresizingMask key="autoresizingMask"/>
-                    <buttonCell key="cell" type="push" title="Choose..." bezelStyle="rounded" alignment="center" controlSize="small" borderStyle="border" tag="2" inset="2" id="1611">
-                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                        <font key="font" metaFont="smallSystem"/>
-                    </buttonCell>
-                </button>
-                <form verticalHuggingPriority="750" fixedFrame="YES" mode="track" allowsEmptySelection="NO" autosizesCells="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1599">
-                    <rect key="frame" x="-4" y="374" width="312" height="100"/>
-                    <autoresizingMask key="autoresizingMask"/>
-                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                    <size key="cellSize" width="312" height="19"/>
-                    <size key="intercellSpacing" width="1" height="8"/>
-                    <formCell key="prototype" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" alignment="justified" title="Field:" id="1606">
-                        <font key="font" metaFont="smallSystem"/>
-                        <font key="titleFont" metaFont="smallSystem"/>
-                    </formCell>
-                    <cells>
-                        <column>
-                            <formCell scrollable="YES" lineBreakMode="clipping" selectable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" alignment="justified" title="ROM 0:" id="1609">
-                                <font key="font" metaFont="smallSystem"/>
-                                <font key="titleFont" metaFont="smallSystem"/>
-                            </formCell>
-                            <formCell scrollable="YES" lineBreakMode="clipping" selectable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" alignment="justified" tag="1" title="ROM 1:" id="1608">
-                                <font key="font" metaFont="smallSystem"/>
-                                <font key="titleFont" metaFont="smallSystem"/>
-                            </formCell>
-                            <formCell scrollable="YES" lineBreakMode="clipping" selectable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" alignment="justified" tag="2" title="ROM 2:" id="1610">
-                                <font key="font" metaFont="smallSystem"/>
-                                <font key="titleFont" metaFont="smallSystem"/>
-                            </formCell>
-                            <formCell scrollable="YES" lineBreakMode="clipping" selectable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" alignment="justified" tag="3" title="ROM 3:" id="1607">
-                                <font key="font" metaFont="smallSystem"/>
-                                <font key="titleFont" metaFont="smallSystem"/>
-                            </formCell>
-                        </column>
-                    </cells>
-                </form>
-                <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1600">
-                    <rect key="frame" x="311" y="449" width="77" height="28"/>
-                    <autoresizingMask key="autoresizingMask"/>
-                    <buttonCell key="cell" type="push" title="Choose..." bezelStyle="rounded" alignment="center" controlSize="small" borderStyle="border" inset="2" id="1605">
-                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                        <font key="font" metaFont="smallSystem"/>
-                    </buttonCell>
-                </button>
-                <button tag="3" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1601">
-                    <rect key="frame" x="311" y="368" width="77" height="28"/>
-                    <autoresizingMask key="autoresizingMask"/>
-                    <buttonCell key="cell" type="push" title="Choose..." bezelStyle="rounded" alignment="center" controlSize="small" borderStyle="border" tag="3" inset="2" id="1604">
-                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                        <font key="font" metaFont="smallSystem"/>
-                    </buttonCell>
-                </button>
-                <button tag="1" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1602">
-                    <rect key="frame" x="311" y="422" width="77" height="28"/>
-                    <autoresizingMask key="autoresizingMask"/>
-                    <buttonCell key="cell" type="push" title="Choose..." bezelStyle="rounded" alignment="center" controlSize="small" borderStyle="border" tag="1" inset="2" id="1603">
-                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                        <font key="font" metaFont="smallSystem"/>
-                    </buttonCell>
-                </button>
                 <scrollView fixedFrame="YES" autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1587">
                     <rect key="frame" x="20" y="19" width="137" height="322"/>
                     <autoresizingMask key="autoresizingMask"/>
@@ -1593,85 +1529,126 @@
                         <autoresizingMask key="autoresizingMask"/>
                     </tableHeaderView>
                 </scrollView>
-                <form verticalHuggingPriority="750" fixedFrame="YES" mode="track" allowsEmptySelection="NO" autosizesCells="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1589">
-                    <rect key="frame" x="165" y="240" width="487" height="100"/>
+                <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="lbl-rom0">
+                    <rect key="frame" x="165" y="321" width="42" height="19"/>
                     <autoresizingMask key="autoresizingMask"/>
-                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                    <size key="cellSize" width="487" height="19"/>
-                    <size key="intercellSpacing" width="1" height="8"/>
-                    <formCell key="prototype" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" alignment="justified" title="Field:" id="1625">
+                    <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="ROM 0:" id="lbl-rom0-cell">
                         <font key="font" metaFont="smallSystem"/>
-                        <font key="titleFont" metaFont="smallSystem"/>
-                    </formCell>
-                    <cells>
-                        <column>
-                            <formCell scrollable="YES" lineBreakMode="clipping" selectable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" alignment="justified" title="ROM 0:" id="1628">
-                                <font key="font" metaFont="smallSystem"/>
-                                <font key="titleFont" metaFont="smallSystem"/>
-                                <connections>
-                                    <binding destination="533" name="value" keyPath="selection.rom0" id="1644">
-                                        <dictionary key="options">
-                                            <integer key="NSAllowsEditingMultipleValuesSelection" value="0"/>
-                                        </dictionary>
-                                    </binding>
-                                    <binding destination="533" name="enabled" keyPath="selection.rom0" id="1652">
-                                        <dictionary key="options">
-                                            <string key="NSValueTransformerName">NSIsNotNil</string>
-                                        </dictionary>
-                                    </binding>
-                                </connections>
-                            </formCell>
-                            <formCell scrollable="YES" lineBreakMode="clipping" selectable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" alignment="justified" tag="1" title="ROM 1:" id="1627">
-                                <font key="font" metaFont="smallSystem"/>
-                                <font key="titleFont" metaFont="smallSystem"/>
-                                <connections>
-                                    <binding destination="533" name="value" keyPath="selection.rom1" id="1646">
-                                        <dictionary key="options">
-                                            <integer key="NSAllowsEditingMultipleValuesSelection" value="0"/>
-                                        </dictionary>
-                                    </binding>
-                                    <binding destination="533" name="enabled" keyPath="selection.rom1" id="1655">
-                                        <dictionary key="options">
-                                            <string key="NSValueTransformerName">NSIsNotNil</string>
-                                        </dictionary>
-                                    </binding>
-                                </connections>
-                            </formCell>
-                            <formCell scrollable="YES" lineBreakMode="clipping" selectable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" alignment="justified" tag="2" title="ROM 2:" id="1629">
-                                <font key="font" metaFont="smallSystem"/>
-                                <font key="titleFont" metaFont="smallSystem"/>
-                                <connections>
-                                    <binding destination="533" name="value" keyPath="selection.rom2" id="1648">
-                                        <dictionary key="options">
-                                            <integer key="NSAllowsEditingMultipleValuesSelection" value="0"/>
-                                        </dictionary>
-                                    </binding>
-                                    <binding destination="533" name="enabled" keyPath="selection.rom2" id="1657">
-                                        <dictionary key="options">
-                                            <string key="NSValueTransformerName">NSIsNotNil</string>
-                                        </dictionary>
-                                    </binding>
-                                </connections>
-                            </formCell>
-                            <formCell scrollable="YES" lineBreakMode="clipping" selectable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" alignment="justified" tag="3" title="ROM 3:" id="1626">
-                                <font key="font" metaFont="smallSystem"/>
-                                <font key="titleFont" metaFont="smallSystem"/>
-                                <connections>
-                                    <binding destination="533" name="enabled" keyPath="selection.rom2" id="1659">
-                                        <dictionary key="options">
-                                            <string key="NSValueTransformerName">NSIsNotNil</string>
-                                        </dictionary>
-                                    </binding>
-                                    <binding destination="533" name="value" keyPath="selection.rom3" id="1650">
-                                        <dictionary key="options">
-                                            <integer key="NSAllowsEditingMultipleValuesSelection" value="0"/>
-                                        </dictionary>
-                                    </binding>
-                                </connections>
-                            </formCell>
-                        </column>
-                    </cells>
-                </form>
+                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
+                <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1628">
+                    <rect key="frame" x="211" y="321" width="441" height="19"/>
+                    <autoresizingMask key="autoresizingMask"/>
+                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" alignment="left" id="1628-cell">
+                        <font key="font" metaFont="smallSystem"/>
+                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                    <connections>
+                        <binding destination="533" name="value" keyPath="selection.rom0" id="1644">
+                            <dictionary key="options">
+                                <integer key="NSAllowsEditingMultipleValuesSelection" value="0"/>
+                            </dictionary>
+                        </binding>
+                        <binding destination="533" name="enabled" keyPath="selection.rom0" id="1652">
+                            <dictionary key="options">
+                                <string key="NSValueTransformerName">NSIsNotNil</string>
+                            </dictionary>
+                        </binding>
+                    </connections>
+                </textField>
+                <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="lbl-rom1">
+                    <rect key="frame" x="165" y="294" width="42" height="19"/>
+                    <autoresizingMask key="autoresizingMask"/>
+                    <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="ROM 1:" id="lbl-rom1-cell">
+                        <font key="font" metaFont="smallSystem"/>
+                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
+                <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1627">
+                    <rect key="frame" x="211" y="294" width="441" height="19"/>
+                    <autoresizingMask key="autoresizingMask"/>
+                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" alignment="left" id="1627-cell">
+                        <font key="font" metaFont="smallSystem"/>
+                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                    <connections>
+                        <binding destination="533" name="value" keyPath="selection.rom1" id="1646">
+                            <dictionary key="options">
+                                <integer key="NSAllowsEditingMultipleValuesSelection" value="0"/>
+                            </dictionary>
+                        </binding>
+                        <binding destination="533" name="enabled" keyPath="selection.rom1" id="1655">
+                            <dictionary key="options">
+                                <string key="NSValueTransformerName">NSIsNotNil</string>
+                            </dictionary>
+                        </binding>
+                    </connections>
+                </textField>
+                <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="lbl-rom2">
+                    <rect key="frame" x="165" y="267" width="42" height="19"/>
+                    <autoresizingMask key="autoresizingMask"/>
+                    <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="ROM 2:" id="lbl-rom2-cell">
+                        <font key="font" metaFont="smallSystem"/>
+                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
+                <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1629">
+                    <rect key="frame" x="211" y="267" width="441" height="19"/>
+                    <autoresizingMask key="autoresizingMask"/>
+                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" alignment="left" id="1629-cell">
+                        <font key="font" metaFont="smallSystem"/>
+                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                    <connections>
+                        <binding destination="533" name="value" keyPath="selection.rom2" id="1648">
+                            <dictionary key="options">
+                                <integer key="NSAllowsEditingMultipleValuesSelection" value="0"/>
+                            </dictionary>
+                        </binding>
+                        <binding destination="533" name="enabled" keyPath="selection.rom2" id="1657">
+                            <dictionary key="options">
+                                <string key="NSValueTransformerName">NSIsNotNil</string>
+                            </dictionary>
+                        </binding>
+                    </connections>
+                </textField>
+                <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="lbl-rom3">
+                    <rect key="frame" x="165" y="240" width="42" height="19"/>
+                    <autoresizingMask key="autoresizingMask"/>
+                    <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="ROM 3:" id="lbl-rom3-cell">
+                        <font key="font" metaFont="smallSystem"/>
+                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
+                <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1626">
+                    <rect key="frame" x="211" y="240" width="441" height="19"/>
+                    <autoresizingMask key="autoresizingMask"/>
+                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" alignment="left" id="1626-cell">
+                        <font key="font" metaFont="smallSystem"/>
+                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                    <connections>
+                        <binding destination="533" name="enabled" keyPath="selection.rom2" id="1659">
+                            <dictionary key="options">
+                                <string key="NSValueTransformerName">NSIsNotNil</string>
+                            </dictionary>
+                        </binding>
+                        <binding destination="533" name="value" keyPath="selection.rom3" id="1650">
+                            <dictionary key="options">
+                                <integer key="NSAllowsEditingMultipleValuesSelection" value="0"/>
+                            </dictionary>
+                        </binding>
+                    </connections>
+                </textField>
                 <button tag="2" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1583">
                     <rect key="frame" x="729" y="263" width="57" height="28"/>
                     <autoresizingMask key="autoresizingMask"/>

--- a/fusepb/xibs/SaveBinary.xib
+++ b/fusepb/xibs/SaveBinary.xib
@@ -26,40 +26,57 @@
                 <rect key="frame" x="0.0" y="0.0" width="591" height="162"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <form verticalHuggingPriority="750" mode="track" allowsEmptySelection="NO" autosizesCells="NO" id="10">
-                        <rect key="frame" x="33" y="60" width="174" height="52"/>
+                    <textField verticalHuggingPriority="750" id="lbl-start-s">
+                        <rect key="frame" x="33" y="90" width="42" height="22"/>
                         <autoresizingMask key="autoresizingMask"/>
-                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                        <size key="cellSize" width="174" height="22"/>
-                        <size key="intercellSpacing" width="1" height="8"/>
-                        <formCell key="prototype" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" alignment="justified" title="Field:" id="35">
+                        <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="Start:" id="lbl-start-s-cell">
                             <font key="font" metaFont="system"/>
-                            <font key="titleFont" metaFont="system"/>
-                        </formCell>
-                        <cells>
-                            <column>
-                                <formCell scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" alignment="justified" title="Start:" id="8">
-                                    <numberFormatter key="formatter" formatterBehavior="default10_4" usesGroupingSeparator="NO" groupingSize="0" minimumIntegerDigits="0" maximumIntegerDigits="42" id="36" customClass="NumberFormatter">
-                                        <real key="minimum" value="0.0"/>
-                                        <real key="maximum" value="65535"/>
-                                    </numberFormatter>
-                                    <font key="font" metaFont="system"/>
-                                    <font key="titleFont" metaFont="system"/>
-                                </formCell>
-                                <formCell scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" alignment="justified" tag="1" title="Length:" id="11">
-                                    <numberFormatter key="formatter" formatterBehavior="default10_4" usesGroupingSeparator="NO" groupingSize="0" minimumIntegerDigits="0" maximumIntegerDigits="42" id="37">
-                                        <real key="minimum" value="1"/>
-                                        <real key="maximum" value="65535"/>
-                                    </numberFormatter>
-                                    <font key="font" metaFont="system"/>
-                                    <font key="titleFont" metaFont="system"/>
-                                </formCell>
-                            </column>
-                        </cells>
+                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                    </textField>
+                    <textField verticalHuggingPriority="750" id="8">
+                        <rect key="frame" x="79" y="90" width="128" height="22"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" alignment="left" id="8-cell">
+                            <numberFormatter key="formatter" formatterBehavior="default10_4" usesGroupingSeparator="NO" groupingSize="0" minimumIntegerDigits="0" maximumIntegerDigits="42" id="36" customClass="NumberFormatter">
+                                <real key="minimum" value="0.0"/>
+                                <real key="maximum" value="65535"/>
+                            </numberFormatter>
+                            <font key="font" metaFont="system"/>
+                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
                         <connections>
                             <outlet property="delegate" destination="-2" id="27"/>
+                            <outlet property="nextKeyView" destination="11" id="8-nkv"/>
                         </connections>
-                    </form>
+                    </textField>
+                    <textField verticalHuggingPriority="750" id="lbl-length-s">
+                        <rect key="frame" x="33" y="60" width="55" height="22"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                        <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="Length:" id="lbl-length-s-cell">
+                            <font key="font" metaFont="system"/>
+                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                    </textField>
+                    <textField verticalHuggingPriority="750" id="11">
+                        <rect key="frame" x="92" y="60" width="115" height="22"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" alignment="left" id="11-cell">
+                            <numberFormatter key="formatter" formatterBehavior="default10_4" usesGroupingSeparator="NO" groupingSize="0" minimumIntegerDigits="0" maximumIntegerDigits="42" id="37">
+                                <real key="minimum" value="1"/>
+                                <real key="maximum" value="65535"/>
+                            </numberFormatter>
+                            <font key="font" metaFont="system"/>
+                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                        <connections>
+                            <outlet property="delegate" destination="-2" id="27b"/>
+                        </connections>
+                    </textField>
                     <button verticalHuggingPriority="750" id="13">
                         <rect key="frame" x="409" y="12" width="84" height="32"/>
                         <autoresizingMask key="autoresizingMask"/>
@@ -96,29 +113,28 @@ DQ
                             <action selector="chooseFile:" target="-2" id="23"/>
                         </connections>
                     </button>
-                    <form verticalHuggingPriority="750" mode="track" allowsEmptySelection="NO" autosizesCells="NO" id="5">
-                        <rect key="frame" x="20" y="120" width="455" height="22"/>
+                    <textField verticalHuggingPriority="750" id="lbl-file-s">
+                        <rect key="frame" x="20" y="120" width="65" height="22"/>
                         <autoresizingMask key="autoresizingMask"/>
-                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                        <size key="cellSize" width="455" height="22"/>
-                        <size key="intercellSpacing" width="1" height="8"/>
-                        <formCell key="prototype" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" alignment="justified" title="Field:" id="34">
+                        <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="Filename:" id="lbl-file-s-cell">
                             <font key="font" metaFont="system"/>
-                            <font key="titleFont" metaFont="system"/>
-                        </formCell>
-                        <cells>
-                            <column>
-                                <formCell scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" alignment="justified" title="Filename:" id="9">
-                                    <font key="font" metaFont="system"/>
-                                    <font key="titleFont" metaFont="system"/>
-                                </formCell>
-                            </column>
-                        </cells>
+                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                    </textField>
+                    <textField verticalHuggingPriority="750" id="9">
+                        <rect key="frame" x="89" y="120" width="386" height="22"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" alignment="left" id="9-cell">
+                            <font key="font" metaFont="system"/>
+                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
                         <connections>
                             <outlet property="delegate" destination="-2" id="26"/>
-                            <outlet property="nextKeyView" destination="10" id="29"/>
+                            <outlet property="nextKeyView" destination="8" id="29"/>
                         </connections>
-                    </form>
+                    </textField>
                 </subviews>
             </view>
             <connections>


### PR DESCRIPTION
# Fix: Text turns black in dark mode after clicking form fields

## Symptom

In several dialogs, text fields display white text on a gray background, which is correct for dark mode. After clicking
into any of these fields and then clicking away, the text turns black and becomes nearly invisible against the dark
background. Affected dialogs:

- Preferences (ROM tab, Peripheral tab)
- Poke Finder
- Import Binary Data
- Export Binary Data

<img width="941" height="539" alt="before" src="https://github.com/user-attachments/assets/a0b77a9b-0a03-4494-ac9b-0474334c16c0" />

## Root cause

These fields used `NSForm` / `NSFormCell`, a deprecated control that predates dark mode. `NSFormCell` inherits from
`NSActionCell`, not `NSTextFieldCell`, so it has no `textColor` property.

When the user clicks a cell, `NSForm` installs a shared field editor (an `NSTextView`). When the field editor resigns,
`NSFormCell`'s internal drawing state changes in a way that produces black text, despite all inspectable state (the
private `_textAttributes` dictionary, the drawing appearance, the resolved `controlTextColor`, `_cFlags`, and
`backgroundStyle`) remaining correct. The bug is inside `NSFormCell`'s `drawWithFrame:inView:` implementation and cannot
be worked around through any public or private API on the cell.

## Fix

Replaced all `NSForm` instances with individual `NSTextField` controls, which is Apple's own recommended migration
path (from the `NSFormCell.h` header: *"for new apps, prefer to use NSTextFields directly instead of NSForm"*).

Each form cell became a label (`NSTextField`, non-editable, right-aligned) paired with a value field (`NSTextField` with
`NSTextFieldCell`). The value fields preserve the same bindings, formatters, delegate connections, and key view chains
as the original form cells.

<img width="941" height="539" alt="after" src="https://github.com/user-attachments/assets/630982d8-a1f4-4cd4-a2b2-98433141f499" />

### Preferences — ROM tab

The four-row `NSForm` (bound to `machineRomsController`) was replaced with four label + text field pairs. An off-screen
duplicate form and its orphan buttons were deleted.

### Preferences — Peripheral tab

The single-row MDR cartridge length `NSForm` was replaced with a label + editable text field pair, preserving the
existing `NumberFormatter` and user defaults binding.

### Poke Finder

The two-row `NSForm` ("Search for:" / "Possible locations:") was replaced with two label and text field pairs. The action
connection on the search field and the key view chain to the match list were preserved.

### Import / Export Binary Data

Each dialog had two `NSForm` instances (a filename field and a start/length pair). All were replaced with label + text
field pairs, preserving the `NumberFormatter` instances, delegate connections, and key view chains.
