### PR TITLE
Defer setServer until after fuse_init to fix startup deadlock

### DIFF
--- a/fusepb/models/Emulator.m
+++ b/fusepb/models/Emulator.m
@@ -186,7 +186,6 @@ static Emulator *instance = nil;
                       sendPort:[portArray objectAtIndex:1]];
   [serverConnection setRootObject:self];
   proxy_view = (id)[serverConnection rootProxy];
-  [proxy_view setServer:self];
 
   /* Load saved ROM paths before startup so the sandbox scope covers custom ROMs on relaunch. */
   read_config_file( &settings_current );
@@ -196,6 +195,8 @@ static Emulator *instance = nil;
     fprintf( stderr, "%s: error initialising -- giving up!\n", fuse_progname );
   }
   [Emulator endROMScopedAccess:romURLs];
+
+  [proxy_view setServer:self];
 
   while( !fuse_exiting ) {
     [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode


### PR DESCRIPTION
If the app window loses focus while `fuse_init` is running, the main thread fires `windowDidResignKey:` which calls `[proxy_emulator keyboardReleaseAll]` via Distributed Objects. That DO call blocks waiting for the emulation thread, which is itself blocked in `performSelectorOnMainThread:waitUntilDone:YES` inside `createTexture:` — waiting for the main thread. Neither can proceed.

Deferring `[proxy_view setServer:self]` until after `fuse_init` ensures `proxy_emulator` is nil during init, making the `windowDidResignKey:` call a harmless no-op.