### PR TITLE
Fix hang when opening file triggers machine change

### DIFF
--- a/fusepb/views/DisplayOpenGLView.m
+++ b/fusepb/views/DisplayOpenGLView.m
@@ -646,7 +646,12 @@ static DisplayOpenGLView *instance = nil;
   GLuint i;
 
   [[self openGLContext] makeCurrentContext];
-  [self performSelectorOnMainThread:@selector(update) withObject:[self openGLContext] waitUntilDone:YES];
+  /* -update must only run on the main thread. When called from the
+     emulation thread (e.g. machine change during openFile:), skip it;
+     the drawable geometry is already valid from the last reshape. */
+  if ([NSThread isMainThread]) {
+    [self update];
+  }
   
   glGenTextures( MAX_SCREEN_BUFFERS, screenTexId );
 


### PR DESCRIPTION
# Fix: Hang when opening a file that triggers a machine change

## Symptom

FuseX freezes when opening a snapshot file for a different machine type via File → Open. The hang is permanent.

## Root cause

`FuseController -open:` runs on the main thread and makes a series of synchronous Distributed Objects (DO) calls to the emulation thread:

1. `[proxy pause]` — pause the emulator
2. `[proxy openFile:]` — load the file
3. `[proxy unpause]` — resume the emulator

Each DO call blocks the main thread's run loop in `NSConnectionReplyMode` until the emulation thread replies.

When the opened file is a snapshot for a *different* machine type, `utils_open_file` triggers `machine_select` → `machine_select_machine` → `uidisplay_init` → `[DisplayOpenGLView createTexture:]`.

`createTexture:` called `[self performSelectorOnMainThread:@selector(update) withObject:... waitUntilDone:YES]` to synchronize the OpenGL drawable on the main thread. But the main thread is blocked in `NSConnectionReplyMode` waiting
for the DO reply. `performSelectorOnMainThread:waitUntilDone:YES` queues work in `NSDefaultRunLoopMode`, which the main thread does not process while in `NSConnectionReplyMode`. Neither thread can proceed: **deadlock**.

The same pattern was triggered by both the `openFile:` DO call and the subsequent `unpause:` DO call (if a deferred approach is used), since any synchronous DO call from the main thread creates the same window.

## Fix

`createTexture:` now calls `[self update]` only when running on the main thread. When called from the emulation thread (the deadlock scenario), the `update` call is skipped. The OpenGL context is still made current before texture creation, which is sufficient. Any view geometry update that `update` would have handled will be applied by the next `reshape` → `doReshape` call, which always runs on the main thread.