### PR TITLE
Fix: use-after-free crash in Preferences ROM table and joystick lists

### DIFF
--- a/fusepb/content_arrays/CAMachines.m
+++ b/fusepb/content_arrays/CAMachines.m
@@ -38,7 +38,7 @@
     if (!machines) {
       size_t i;
 
-      machines = [NSMutableArray arrayWithCapacity:machine_count];
+      machines = [[NSMutableArray alloc] initWithCapacity:machine_count];
 
       for( i=0; i<machine_count; i++ ) {
         [machines addObject:

--- a/fusepb/content_arrays/HIDJoysticks.m
+++ b/fusepb/content_arrays/HIDJoysticks.m
@@ -39,7 +39,7 @@
   if (!joysticks) {
     size_t i;
 
-    joysticks = [NSMutableArray arrayWithCapacity:joysticks_supported+1];
+    joysticks = [[NSMutableArray alloc] initWithCapacity:joysticks_supported+1];
 
     [joysticks addObject:[HIDJoystick joystickWithName:@"None" andType:0]];
     if( joysticks_supported > 0 ){

--- a/fusepb/content_arrays/Joysticks.m
+++ b/fusepb/content_arrays/Joysticks.m
@@ -38,7 +38,7 @@
   if (!joysticks) {
     size_t i;
 
-    joysticks = [NSMutableArray arrayWithCapacity:JOYSTICK_TYPE_COUNT];
+    joysticks = [[NSMutableArray alloc] initWithCapacity:JOYSTICK_TYPE_COUNT];
 
     for( i=0; i<JOYSTICK_TYPE_COUNT; i++ ) {
       [joysticks addObject:


### PR DESCRIPTION
## Symptom

FuseX crashed with `EXC_BAD_ACCESS (SIGSEGV)` — "possible pointer authentication failure" — on Thread 0 while the Preferences window was open. The crash occurred inside `objc_msgSend` during NSTableView rendering of the ROM configuration table.

Abbreviated stack:

```
0  libobjc      objc_msgSend + 32
1  FuseX        -[Machine machineName]
2  Foundation   -[NSArray(NSKeyValueCoding) valueForKey:]
   ...
9  AppKit       -[NSTextValueBinder updateTableColumnDataCell:forDisplayAtIndex:]
   ...
14 AppKit       -[NSTableView preparedCellAtColumn:row:]
```

The receiver passed to `objc_msgSend` (x0) pointed to a `Machine` object whose `isa` had been overwritten by the allocator after the object was freed, causing PAC validation to fail.

## Root cause

`+[Machine allMachines]` in `CAMachines.m` used `+arrayWithCapacity:` to create the static registry array:

```objc
static NSMutableArray *machines;
if (!machines) {
    machines = [NSMutableArray arrayWithCapacity:machine_count];  // autoreleased!
    ...
}
return machines;
```

`+arrayWithCapacity:` returns an autoreleased object. The static local `machines` never retained it. After the first run-loop cycle drained the autorelease pool, the array was freed — but the static pointer still held the old address (non-nil).

On any subsequent call to `+allMachines` (e.g., reopening Preferences), `if (!machines)` evaluated to false on the dangling pointer, so the method returned freed memory directly. `+machineForType:` then called `-objectEnumerator` on this freed array; depending on memory reuse, it either crashed immediately or returned a garbage `Machine *` that ended up stored in
a `machineRoms` dictionary. When AppKit later called `-machineName` on that pointer via Cocoa Bindings, `objc_msgSend` hit the corrupted `isa` and faulted.

The bug was latent for a long time but became reliably reproducible on macOS 26, which poisons freed memory more aggressively, making the PAC failure deterministic.

## Fix

Use `+alloc`/`-initWithCapacity:` so the static variable owns the array:

```objc
machines = [[NSMutableArray alloc] initWithCapacity:machine_count];
```

The `Machine` registry is intentionally a process-lifetime singleton, so retaining it forever is correct. `Machine` objects inside the array are also safe to hold indefinitely — they wrap constant `libspectrum` machine metadata that never changes.

The same fix was applied to two sibling files with the identical pattern:

- `HIDJoysticks.m` — `+[HIDJoystick allJoysticks]`
- `Joysticks.m` — `+[Joystick allJoysticks]`
