### PR TITLE
Autoload tape/disk when launched with a custom ROM path

### DIFF
--- a/tape.c
+++ b/tape.c
@@ -372,7 +372,7 @@ tape_write( const char* filename )
 
 int tape_can_autoload( void )
 {
-  return( auto_load_is_enabled() && !memory_custom_rom() );
+  return auto_load_is_enabled();
 }
 
 /* Load the next tape block into memory; returns 0 if a block was


### PR DESCRIPTION
Autoloading was previously disabled whenever a custom ROM path was set. The original rationale was likely that a custom ROM could differ enough from the stock one that the phantom typist would be unable to drive the autoload sequence — or, worse, would blindly inject keystrokes into a different boot prompt and leave the machine in an unexpected state.

In practice, Fuse ships without many of the ROMs it references (for licensing reasons), so users routinely have to supply custom ROMs — for example, to emulate a Pentagon 128. Disabling autoload in that case is a disservice: the ROM is usually a drop-in replacement and the phantom typist works fine against it.

A more bulletproof solution would be to hash the loaded ROM and compare it against the hashes of the known stock ROMs, disabling autoload only when the hash doesn't match any of them. That is out of scope for this PR.
