### PR TITLE
Replace modal windows with floating child windows

### DIFF
--- a/fusepb/controllers/DebuggerController.m
+++ b/fusepb/controllers/DebuggerController.m
@@ -58,6 +58,10 @@ static libspectrum_word disassembly_top;
 /* Is the debugger window active (as opposed to the debugger itself)? */
 static int debugger_active;
 
+/* Semaphore that blocks the emulation thread inside ui_debugger_activate()
+   until the user dismisses the debugger (Continue / close). */
+static dispatch_semaphore_t debugger_semaphore;
+
 @implementation DebuggerController
 
 static DebuggerController *singleton = nil;
@@ -102,6 +106,7 @@ static DebuggerController *singleton = nil;
     [super init];
     self = [super initWithWindowNibName:@"Debugger"];
     singleton = self;
+    debugger_semaphore = dispatch_semaphore_create( 0 );
 
     [self performSelectorOnMainThread:@selector(habdleCloseNotification) withObject:nil waitUntilDone:YES];
     [self performSelectorOnMainThread:@selector(setWindowFrameAutosaveName:) withObject:@"DebuggerWindow" waitUntilDone:YES];
@@ -142,7 +147,13 @@ static DebuggerController *singleton = nil;
   [memoryMapContents release];
   memoryMapContents = nil;
 
-  debugger_run();
+  [[self window] unpinFromParent];
+
+  /* Only resume execution when the user dismissed the window directly.
+     If we arrived via deactivate_debugger(), debugger_active is already
+     0 and the caller has set debugger_mode; calling debugger_run() now
+     would overwrite a HALTED set by debugger_step(). */
+  if( debugger_active ) debugger_run();
 }
 
 - (void)eventsDoubleAction:(id)sender
@@ -191,20 +202,36 @@ static DebuggerController *singleton = nil;
 {
   [[DisplayOpenGLView instance] pause];
 
+  /* Breakpoints fire unprompted. Bring FuseX (and the main window) back
+     into view if the user has Cmd-Tabbed away, hidden the app, or
+     minimized the main window — otherwise the Debugger window, as a
+     child of main, would not be visible. After this point the panel
+     behaves like any other child window: it sinks with FuseX when the
+     user switches to another app, and rises with FuseX on return. */
+  [NSApp activateIgnoringOtherApps:YES];
+  NSWindow *mainWindow = [[DisplayOpenGLView instance] window];
+  if( [mainWindow isMiniaturized] ) {
+    [mainWindow deminiaturize:nil];
+  }
+
+  BOOL wasVisible = [[singleton window] isVisible];
   [singleton showWindow:nil];
+  if( !wasVisible ) {
+    [[singleton window] makeFirstResponder:entry];
+  }
+
+  [[singleton window] pinAsChildOf:mainWindow];
 
   [continueButton setEnabled:YES];
   [breakButton setEnabled:NO];
-  if( !debugger_active ) activate_debugger();
-
-  [NSApp runModalForWindow:[self window]];
+  activate_debugger();
 }
 
 - (void)debugger_deactivate:(int)interruptable
 {
   if( debugger_active ) deactivate_debugger();
 
-  [continueButton setEnabled:!interruptable ? YES : NO];
+  [continueButton setEnabled:interruptable ? NO : YES];
   [breakButton setEnabled:interruptable ? YES : NO];
 }
  
@@ -651,7 +678,11 @@ static DebuggerController *singleton = nil;
 int
 ui_debugger_activate( void )
 {
-  [[Emulator instance] debuggerActivate];
+  [[Emulator instance] performSelectorOnMainThread:@selector(debuggerActivate)
+                                        withObject:nil
+                                     waitUntilDone:YES];
+
+  dispatch_semaphore_wait( debugger_semaphore, DISPATCH_TIME_FOREVER );
 
   return 0;
 }
@@ -721,10 +752,10 @@ activate_debugger( void )
 
 static int
 deactivate_debugger( void )
-{ 
-  [NSApp stopModal];
+{
   debugger_active = 0;
   [[DisplayOpenGLView instance] unpause];
+  dispatch_semaphore_signal( debugger_semaphore );
   return 0;
 }
 

--- a/fusepb/controllers/FuseController.h
+++ b/fusepb/controllers/FuseController.h
@@ -164,9 +164,6 @@
 - savePanelAccessoryView;
 @property (getter=saveFileType,readonly) NSPopUpButton* saveFileType;
 
-- (void)releaseCmdKeys:(NSString *)character withCode:(int)keyCode;
-- (void)releaseKey:(int)keyCode;
-
 - (void)ui_menu_activate_media_cartridge:(NSNumber*)active;
 - (void)ui_menu_activate_media_cartridge_dock:(NSNumber*)active;
 - (void)ui_menu_activate_media_cartridge_dock_eject:(NSNumber*)active;

--- a/fusepb/controllers/FuseController.m
+++ b/fusepb/controllers/FuseController.m
@@ -320,9 +320,54 @@ static NSMutableArray *recentSnapFileNames = nil;
 
     recentSnapFileNames = [NSMutableArray arrayWithCapacity:NUM_RECENT_ITEMS];
     [recentSnapFileNames retain];
+
+    /* Resync the emulator's modifier ivars whenever the main window
+       regains key status. AppKit delivers NSFlagsChanged to the key
+       window's first responder, so a modifier release while a utility
+       window was key never reaches DisplayOpenGLView and
+       Emulator.commandDown stays stuck — dropping every subsequent
+       keystroke in Emulator.keyDown:. The user-visible form is the
+       Cmd+, → Preferences flow: open Settings, close, then the
+       Spectrum keyboard ignores everything until the next modifier
+       press triggers a real NSFlagsChanged on the main window. The
+       filter inside the handler skips notifications for other
+       windows. */
+    [[NSNotificationCenter defaultCenter]
+      addObserver:self
+         selector:@selector(mainWindowDidBecomeKey:)
+             name:NSWindowDidBecomeKeyNotification
+           object:nil];
   }
 
   return singleton;
+}
+
+- (void)mainWindowDidBecomeKey:(NSNotification *)note
+{
+  /* The observer is registered with object:nil because the main window
+     does not yet exist when the FuseController singleton is constructed
+     during MainMenu.xib load. Filter to the main emulator window inside
+     the handler — and bail out early if the main window does not yet
+     exist, otherwise a non-nil note object would falsely pass the !=
+     comparison against nil during startup. */
+  NSWindow *mainWindow = [[DisplayOpenGLView instance] window];
+  if( !mainWindow ) return;
+  if( [note object] != mainWindow ) return;
+
+  Emulator *emu = [Emulator instance];
+  if( !emu ) return;
+
+  NSEvent *sync = [NSEvent keyEventWithType:NSFlagsChanged
+                                   location:NSZeroPoint
+                              modifierFlags:[NSEvent modifierFlags]
+                                  timestamp:0
+                               windowNumber:0
+                                    context:nil
+                                 characters:@""
+                charactersIgnoringModifiers:@""
+                                  isARepeat:NO
+                                    keyCode:0];
+  [emu flagsChanged:sync];
 }
 
 - (IBAction)disk_eject_a:(id)sender
@@ -652,7 +697,6 @@ error:
 
     [[DisplayOpenGLView instance] unpause];
   }
-  [self releaseCmdKeys:@"o" withCode:QZ_o];
 }
 
 - (IBAction)reset:(id)sender
@@ -697,13 +741,11 @@ error:
 - (IBAction)rzx_insert_snap:(id)sender
 {
   [[DisplayOpenGLView instance] rzxInsertSnap];
-  [self releaseCmdKeys:@"b" withCode:QZ_b];
 }
 
 - (IBAction)rzx_rollback:(id)sender
 {
   [[DisplayOpenGLView instance] rzxRollback];
-  [self releaseCmdKeys:@"z" withCode:QZ_z];
 }
 
 - (IBAction)rzx_start:(id)sender
@@ -863,7 +905,6 @@ error:
 save_as_exit:
     [[DisplayOpenGLView instance] unpause];
   }
-  [self releaseCmdKeys:@"s" withCode:QZ_s];
 }
 
 - (IBAction)open_screen:(id)sender
@@ -991,13 +1032,11 @@ save_as_exit:
 - (IBAction)joystick_keyboard:(id)sender
 {
   [[DisplayOpenGLView instance] joystickToggleKeyboard];
-  [self releaseCmdKeys:@"j" withCode:QZ_j];
 }
 
 - (IBAction)keyboard_recreated:(id)sender
 {
   [[DisplayOpenGLView instance] keyboardToggleRecreatedZXSpectrum];
-  [self releaseCmdKeys:@"r" withCode:QZ_r];
 }
 
 - (IBAction)keyboard_arrows_shifted:(id)sender
@@ -1032,7 +1071,6 @@ save_as_exit:
 - (IBAction)tape_play:(id)sender
 {
   [[DisplayOpenGLView instance] tapeTogglePlay];
-  [self releaseCmdKeys:@"p" withCode:QZ_p];
 }
 
 - (IBAction)tape_rewind:(id)sender
@@ -1124,13 +1162,11 @@ save_as_exit:
   if( !settings_current.full_screen ) {
     [[NSApp keyWindow] performClose:self];
   }
-  [self releaseCmdKeys:@"q" withCode:QZ_q];
 }
 
 - (IBAction)hide:(id)sender
 {
   [NSApp hide:self];
-  [self releaseCmdKeys:@"h" withCode:QZ_h];
 }
 
 - (IBAction)help:(id)sender
@@ -1138,7 +1174,6 @@ save_as_exit:
   if( !settings_current.full_screen ) {
     [NSApp showHelp:self];
   }
-  [self releaseCmdKeys:@"?" withCode:QZ_SLASH];
 }
 
 - (IBAction)cocoa_break:(id)sender
@@ -1146,13 +1181,30 @@ save_as_exit:
   if ( gdbserver_debugging_enabled ) {
     return;
   }
-  if ( paused ) {
-    debugger_mode = DEBUGGER_MODE_HALTED;
-    paused = 0;
-    [[DebuggerController singleton] debugger_activate:nil];
-  } else {
-    [[DisplayOpenGLView instance] cocoaBreak];
+
+  /* Re-entry: if the Debugger is already showing, bring it forward and
+     leave state alone. Calling debugger_activate: a second time would
+     double-pause and unbalance the counter. */
+  DebuggerController *dbg = [DebuggerController loadedSingleton];
+  if ( dbg && [[dbg window] isVisible] ) {
+    [[dbg window] makeKeyAndOrderFront:nil];
+    return;
   }
+
+  if ( paused ) {
+    /* User-pause: release the user-pause contribution so the timer can
+       run, then set HALTED. The emulator detects HALTED on the next
+       instruction and ui_debugger_activate parks the thread on the
+       semaphore via the proper path. The user-pause is not restored on
+       dismissal — the user explicitly opened the Debugger from a paused
+       state, and Continue means "resume." */
+    paused = 0;
+    [[DisplayOpenGLView instance] unpause];
+  }
+  /* The utility-window case (fuse_emulation_paused > 0 && !paused) is
+     unreachable: validateMenuItem: disables the Debugger menu item in
+     that state. */
+  [[DisplayOpenGLView instance] cocoaBreak];
   [self setPauseState];
 }
 
@@ -1186,7 +1238,6 @@ save_as_exit:
       [keyboardController showCloseWindow:self];
     }
   }
-  [self releaseCmdKeys:@"k" withCode:QZ_k];
 }
 
 - (IBAction)showLoadBinaryPane:(id)sender
@@ -1248,7 +1299,6 @@ save_as_exit:
     }
     [preferencesController showWindow:self];
   }
-  [self releaseCmdKeys:@"." withCode:QZ_PERIOD];
 }
 
 - (IBAction)saveFileTypeClicked:(id)sender;
@@ -1280,6 +1330,8 @@ save_as_exit:
 
 - (void)dealloc
 {
+  [[NSNotificationCenter defaultCenter] removeObserver:self];
+
   [tapeBrowserController release];
   [keyboardController release];
   [saveBinaryController release];
@@ -1289,55 +1341,6 @@ save_as_exit:
   [rollbackController release];
   [savePanelAccessoryView release];
   [super dealloc];
-}
-
-/*------------------------------------------------------------------------------
- *  releaseCmdKeys - This method fixes an issue when modal windows are used with
- *    the Mac OSX version of the SDL library.
- *    As the SDL normally captures all keystrokes, but we need to type in some
- *    Mac windows, all of the control menu windows run in modal mode.  However,
- *    when this happens, the release of the command key and the shortcut key
- *    are not sent to SDL.  We have to manually cause these events to happen
- *    to keep the SDL library in a sane state, otherwise only every other
- *    shortcut keypress will work.
- *-----------------------------------------------------------------------------*/
-- (void) releaseCmdKeys:(NSString *)character withCode:(int)keyCode
-{
-    NSEvent *event1, *event2;
-    NSPoint point = { 0, 0 };
-
-    event1 = [NSEvent keyEventWithType:NSKeyUp location:point modifierFlags:0
-                timestamp:0 windowNumber:0 context:nil characters:character
-                charactersIgnoringModifiers:character isARepeat:NO
-                keyCode:keyCode];
-    [NSApp postEvent:event1 atStart:NO];
-
-    event2 = [NSEvent keyEventWithType:NSFlagsChanged location:point
-                modifierFlags:0 timestamp:0 windowNumber:0 context:nil
-                characters:nil charactersIgnoringModifiers:nil isARepeat:NO
-                keyCode:0];
-    [NSApp postEvent:event2 atStart:NO];
-}
-
-/*------------------------------------------------------------------------------
- *  releaseKey - This method fixes an issue when modal windows are used with
- *    the Mac OSX version of the SDL library.
- *    As the SDL normally captures all keystrokes, but we need to type in some
- *    Mac windows, all of the control menu windows run in modal mode.  However,
- *    when this happens, the release of function key which started the process
- *    is not sent to SDL.  We have to manually cause these events to happen
- *    to keep the SDL library in a sane state, otherwise only everyother shortcut
- *    keypress will work.
- *-----------------------------------------------------------------------------*/
-- (void) releaseKey:(int)keyCode
-{
-  NSEvent *event1;
-  NSPoint point = { 0, 0 };
-
-  event1 = [NSEvent keyEventWithType:NSKeyUp location:point modifierFlags:0
-              timestamp:0 windowNumber:0 context:nil characters:@" "
-              charactersIgnoringModifiers:@" " isARepeat:NO keyCode:keyCode];
-  [NSApp postEvent:event1 atStart:NO];
 }
 
 - (void)ui_menu_activate_media_cartridge:(NSNumber*)active
@@ -2112,7 +2115,22 @@ save_as_exit:
     return multiface == 0 ? NO : YES;
     break;
   case 176:
-    return debuggerEnabled == 0 ? NO : YES;
+    if( !debuggerEnabled ) return NO;
+    /* Disable Machine→Debugger when a utility window is holding the
+       emulator paused and the Debugger itself is not already up. The
+       menu cannot do anything useful in that state: cocoa_break: sets
+       HALTED, but z80 is not executing because the utility window's
+       pause stopped the timer, so no trap fires and the Debugger
+       window never appears until the user closes the utility. The
+       comparison must subtract the user-pause contribution so the
+       guard fires regardless of whether Machine→Pause is also set —
+       the utility-window holds are the part that breaks the trap
+       path. */
+    if( fuse_emulation_paused > (paused ? 1 : 0) ) {
+      DebuggerController *dbg = [DebuggerController loadedSingleton];
+      if( !dbg || ![[dbg window] isVisible] ) return NO;
+    }
+    return YES;
     break;
   default:
     return YES;

--- a/fusepb/controllers/JoystickConfigurationController.m
+++ b/fusepb/controllers/JoystickConfigurationController.m
@@ -154,7 +154,7 @@ static const unsigned int key_menu_count = sizeof( key_menu ) / sizeof( key_menu
 
 - (IBAction)cancel:(id)sender
 {
-  [NSApp stopModal];
+  [[self window] unpinFromParent];
   [[self window] close];
 }
 
@@ -165,7 +165,16 @@ static const unsigned int key_menu_count = sizeof( key_menu ) / sizeof( key_menu
 
   joyNum = [sender tag];
 
+  /* Capture the parent before [super showWindow:] takes key status away. */
+  NSWindow *parent = [NSApp keyWindow];
+
   [super showWindow:sender];
+
+  /* Pin to the parent (Preferences) so this sub-dialog cannot be hidden
+     behind it. Preferences is itself a child of the main emulator window,
+     making this a grandchild — addChildWindow: is the only mechanism that
+     enforces z-order for two windows at the same level. */
+  [[self window] pinAsChildOf:parent];
 
   [joyXAxis removeAllItems];
   [joyYAxis removeAllItems];
@@ -375,8 +384,6 @@ static const unsigned int key_menu_count = sizeof( key_menu ) / sizeof( key_menu
   default:
     assert(0);
   }
-
-  [NSApp runModalForWindow:[self window]];
 }
 
 @end

--- a/fusepb/controllers/JoystickConfigurationController.m
+++ b/fusepb/controllers/JoystickConfigurationController.m
@@ -154,8 +154,22 @@ static const unsigned int key_menu_count = sizeof( key_menu ) / sizeof( key_menu
 
 - (IBAction)cancel:(id)sender
 {
-  [[self window] unpinFromParent];
+  /* All dismissal paths (Apply, Cancel, red X, Preferences close
+     cascade) funnel through handleWillClose: via the
+     NSWindowWillCloseNotification observer registered in showWindow:,
+     so this just closes the window and lets the observer do the
+     parent-child teardown. */
   [[self window] close];
+}
+
+- (void)handleWillClose:(NSNotification *)note
+{
+  [[NSNotificationCenter defaultCenter]
+    removeObserver:self
+              name:@"NSWindowWillCloseNotification"
+            object:[self window]];
+
+  [[self window] unpinFromParent];
 }
 
 - (void)showWindow:(id)sender
@@ -175,6 +189,20 @@ static const unsigned int key_menu_count = sizeof( key_menu ) / sizeof( key_menu
      making this a grandchild — addChildWindow: is the only mechanism that
      enforces z-order for two windows at the same level. */
   [[self window] pinAsChildOf:parent];
+
+  /* Register the close observer here. Joystick is reused across Joy1
+     and Joy2 invocations on the same open window (the spec disallows a
+     singleton early-return guard for that reason), so showWindow: may
+     run a second time without an intervening close — remove any prior
+     registration before adding to keep this idempotent. */
+  NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
+  [nc removeObserver:self
+                name:@"NSWindowWillCloseNotification"
+              object:[self window]];
+  [nc addObserver:self
+        selector:@selector(handleWillClose:)
+            name:@"NSWindowWillCloseNotification"
+          object:[self window]];
 
   [joyXAxis removeAllItems];
   [joyYAxis removeAllItems];

--- a/fusepb/controllers/LoadBinaryController.m
+++ b/fusepb/controllers/LoadBinaryController.m
@@ -89,25 +89,30 @@ static utils_file u_file;
 
 - (IBAction)cancel:(id)sender
 {
-  [NSApp stopModal];
+  [[self window] unpinFromParent];
   [[self window] close];
-  
+
   [[DisplayOpenGLView instance] unpause];
 }
 
 - (void)showWindow:(id)sender
 {
+  if( [[self window] isVisible] ) {
+    [[self window] makeKeyAndOrderFront:sender];
+    return;
+  }
+
   [[DisplayOpenGLView instance] pause];
-  
+
   [super showWindow:sender];
+
+  [[self window] pinAsChildOf:[[DisplayOpenGLView instance] window]];
 
   [file setStringValue:@""];
   [start setStringValue:@""];
   [length setStringValue:@""];
   
   [apply setEnabled:NO];
-
-  [NSApp runModalForWindow:[self window]];
 }
 
 - (IBAction)chooseFile:(id)sender

--- a/fusepb/controllers/MemoryBrowserController.m
+++ b/fusepb/controllers/MemoryBrowserController.m
@@ -59,14 +59,17 @@ id notificationObserver;
   NSString *address;
   NSMutableString *hex, *data;
 
+  if( [[self window] isVisible] ) {
+    [[self window] makeKeyAndOrderFront:sender];
+    return;
+  }
+
   notificationObserver =
     [nc addObserverForName:@"NSWindowWillCloseNotification"
                     object:[self window]
                      queue:mainQueue
                 usingBlock:^(NSNotification *note) {
                   [nc removeObserver:notificationObserver];
-                
-                  [NSApp stopModal];
                 
                   [tableContents removeAllObjects];
                 
@@ -75,7 +78,9 @@ id notificationObserver;
                   tableContents = nil;
                 
                   [memoryBrowser reloadData];
-                
+
+                  [[self window] unpinFromParent];
+
                   [[DisplayOpenGLView instance] unpause];
                 }];
   
@@ -105,9 +110,9 @@ id notificationObserver;
 
   [super showWindow:sender];
 
+  [[self window] pinAsChildOf:[[DisplayOpenGLView instance] window]];
+
   [memoryBrowser reloadData];
-  
-  [NSApp runModalForWindow:[self window]];
 }
 
 - (int)numberOfRowsInTableView:(NSTableView *)table

--- a/fusepb/controllers/MemoryBrowserController.m
+++ b/fusepb/controllers/MemoryBrowserController.m
@@ -31,7 +31,7 @@
 
 @implementation MemoryBrowserController
 
-id notificationObserver;
+static id notificationObserver;
 
 - (id)init
 {

--- a/fusepb/controllers/PokeFinderController.m
+++ b/fusepb/controllers/PokeFinderController.m
@@ -94,14 +94,19 @@
 
 - (void)handleWillClose:(NSNotification *)note
 {
-  [NSApp stopModal];
+  [[NSNotificationCenter defaultCenter]
+    removeObserver:self
+              name:@"NSWindowWillCloseNotification"
+            object:[self window]];
 
   [tableContents removeAllObjects];
   [tableContents release];
-  
+
   tableContents = nil;
-  
+
   [matchList reloadData];
+
+  [[self window] unpinFromParent];
 
   [[DisplayOpenGLView instance] unpause];
 }
@@ -109,6 +114,11 @@
 - (void)showWindow:(id)sender
 {
   NSNotificationCenter *nc;
+
+  if( [[self window] isVisible] ) {
+    [[self window] makeKeyAndOrderFront:sender];
+    return;
+  }
 
   nc = [NSNotificationCenter defaultCenter];
   [nc addObserver:self
@@ -120,9 +130,9 @@
 
   [super showWindow:sender];
 
+  [[self window] pinAsChildOf:[[DisplayOpenGLView instance] window]];
+
   [self update_pokefinder];
-  
-  [NSApp runModalForWindow:[self window]];
 }
 
 - (IBAction)search:(id)sender

--- a/fusepb/controllers/PokeMemoryController.m
+++ b/fusepb/controllers/PokeMemoryController.m
@@ -51,8 +51,6 @@ id notificationObserver;
                     object:[self window]
                      queue:mainQueue
                 usingBlock:^(NSNotification *note) {
-                  [NSApp stopModal];
-                
                   for( NSMutableDictionary* trainerModel in [trainersController content] ) {
                     trainer_t* trainer =
                       (trainer_t*)[[trainerModel valueForKey:@"trainerVal"] pointerValue];
@@ -66,7 +64,9 @@ id notificationObserver;
                   [trainersController setContent:nil];
                   
                   [trainers reloadData];
-                
+
+                  [[self window] unpinFromParent];
+
                   [[DisplayOpenGLView instance] unpause];
                 }];
   
@@ -88,6 +88,11 @@ id notificationObserver;
 
 - (void)showWindow:(id)sender
 {
+  if( [[self window] isVisible] ) {
+    [[self window] makeKeyAndOrderFront:sender];
+    return;
+  }
+
   [[DisplayOpenGLView instance] pause];
 
   if( trainer_list ) {
@@ -96,9 +101,9 @@ id notificationObserver;
 
   [super showWindow:sender];
 
+  [[self window] pinAsChildOf:[[DisplayOpenGLView instance] window]];
+
   [trainers reloadData];
-  
-  [NSApp runModalForWindow:[self window]];
 }
 
 - (void)addObjectToPokeList:(NSDictionary*)poke

--- a/fusepb/controllers/PokeMemoryController.m
+++ b/fusepb/controllers/PokeMemoryController.m
@@ -33,7 +33,7 @@ static void trainer_add( gpointer data, gpointer user_data );
 
 @implementation PokeMemoryController
 
-id notificationObserver;
+static id notificationObserver;
 
 - (id)init
 {

--- a/fusepb/controllers/PreferencesController.m
+++ b/fusepb/controllers/PreferencesController.m
@@ -161,6 +161,11 @@
 
 - (void)showWindow:(id)sender
 {
+  if( [[self window] isVisible] ) {
+    [[self window] makeKeyAndOrderFront:sender];
+    return;
+  }
+
   [[DisplayOpenGLView instance] pause];
 
   [machineRomsController setContent:nil];
@@ -176,6 +181,11 @@
 
   [super showWindow:sender];
 
+  /* Pin to the main emulator window. The Joystick sub-dialog adds
+     itself as a child of Preferences when opened, producing a
+     main → Preferences → Joystick chain. */
+  [[self window] pinAsChildOf:[[DisplayOpenGLView instance] window]];
+
   [self setMassStorageType];
   [self setExternalSoundType];
   
@@ -185,12 +195,6 @@
 		 selector:@selector(handleWillClose:)
 			 name:@"NSWindowWillCloseNotification"
 		   object:[self window]];
-
-  [NSApp runModalForWindow:[self window]];
-
-  [machineRomsController setContent:nil];
-  [machineRoms release];
-  machineRoms = nil;
 }
 
 - (void)fixPhantomTypistMode
@@ -219,8 +223,6 @@
 
 - (void)handleWillClose:(NSNotification *)note
 {
-  [NSApp stopModal];
-
   [[NSNotificationCenter defaultCenter] removeObserver:self];
 
   int old_bilinear = settings_current.bilinear_filter;
@@ -273,6 +275,12 @@
     periph_posthook();
     [Emulator endROMScopedAccess:romURLs];
   }
+
+  [machineRomsController setContent:nil];
+  [machineRoms release];
+  machineRoms = nil;
+
+  [[self window] unpinFromParent];
 
   [[DisplayOpenGLView instance] unpause];
 }

--- a/fusepb/controllers/PreferencesController.m
+++ b/fusepb/controllers/PreferencesController.m
@@ -60,6 +60,32 @@
 
 @implementation PreferencesController
 
+/* Set on NSApplicationWillTerminateNotification so handleWillClose:
+   can skip the settings-apply / KVO-teardown work when the close is
+   part of [NSApp terminate:]'s cascade. Touching NSArrayController
+   content or driving graphics hotswaps from inside that cascade
+   reaches the notification observer table while NSWindow is still
+   walking it, producing the strcmp crash in
+   __CFNOTIFICATIONCENTER_IS_CALLING_OUT_TO_AN_OBSERVER__. The work
+   skipped here only matters when the emulator continues running
+   after the window closes; at quit time the settings have already
+   been persisted to NSUserDefaults via the binding chain. */
+static BOOL appTerminating = NO;
+
++ (void)load
+{
+  [[NSNotificationCenter defaultCenter]
+    addObserver:self
+       selector:@selector(handleAppWillTerminate:)
+           name:NSApplicationWillTerminateNotification
+         object:nil];
+}
+
++ (void)handleAppWillTerminate:(NSNotification *)note
+{
+  appTerminating = YES;
+}
+
 +(void) initialize
 {
   ScalerNameToIdTransformer *sNToITransformer;
@@ -224,6 +250,8 @@
 - (void)handleWillClose:(NSNotification *)note
 {
   [[NSNotificationCenter defaultCenter] removeObserver:self];
+
+  if( appTerminating ) return;
 
   int old_bilinear = settings_current.bilinear_filter;
   int old_joy1_number = settings_current.joy1_number;

--- a/fusepb/controllers/RollbackController.m
+++ b/fusepb/controllers/RollbackController.m
@@ -88,23 +88,46 @@ add_point_details( gpointer data, void *user_data );
 
 - (IBAction)cancel:(id)sender
 {
-    [NSApp stopModal];
-    [[self window] close];
+  /* All dismissal paths (OK, Cancel, red X) funnel through
+     handleWillClose: via NSWindowWillCloseNotification, so this just
+     closes the window and lets the observer do the teardown. */
+  [[self window] close];
+}
 
-    [[DisplayOpenGLView instance] unpause];
+- (void)handleWillClose:(NSNotification *)note
+{
+  [[NSNotificationCenter defaultCenter]
+    removeObserver:self
+              name:@"NSWindowWillCloseNotification"
+            object:[self window]];
+
+  [[self window] unpinFromParent];
+
+  [[DisplayOpenGLView instance] unpause];
 }
 
 - (void)showWindow:(id)sender
 {
+  if( [[self window] isVisible] ) {
+    [[self window] makeKeyAndOrderFront:sender];
+    return;
+  }
+
   [[DisplayOpenGLView instance] pause];
-  
+
+  [[NSNotificationCenter defaultCenter]
+    addObserver:self
+       selector:@selector(handleWillClose:)
+           name:@"NSWindowWillCloseNotification"
+         object:[self window]];
+
   [super showWindow:sender];
+
+  [[self window] pinAsChildOf:[[DisplayOpenGLView instance] window]];
 
   [self update];
 
   [okButton setEnabled:NO];
-
-  [NSApp runModalForWindow:[self window]];
 }
 
 - (int)numberOfRowsInTableView:(NSTableView *)table

--- a/fusepb/controllers/SaveBinaryController.m
+++ b/fusepb/controllers/SaveBinaryController.m
@@ -80,25 +80,30 @@
 
 - (IBAction)cancel:(id)sender
 {
-  [NSApp stopModal];
+  [[self window] unpinFromParent];
   [[self window] close];
-  
+
   [[DisplayOpenGLView instance] unpause];
 }
 
 - (void)showWindow:(id)sender
 {
+  if( [[self window] isVisible] ) {
+    [[self window] makeKeyAndOrderFront:sender];
+    return;
+  }
+
   [[DisplayOpenGLView instance] pause];
-  
+
   [super showWindow:sender];
+
+  [[self window] pinAsChildOf:[[DisplayOpenGLView instance] window]];
 
   [file setStringValue:@""];
   [start setStringValue:@""];
   [length setStringValue:@""];
   
   [apply setEnabled:NO];
-
-  [NSApp runModalForWindow:[self window]];
 }
 
 - (IBAction)chooseFile:(id)sender

--- a/fusepb/models/Emulator.h
+++ b/fusepb/models/Emulator.h
@@ -36,6 +36,12 @@
 {
   int isPaused;
   NSTimer* timer;
+  /* Set once in connectWithPorts: on the emulator thread, cleared at
+     teardown. Read from arbitrary callers (typically main) in pause /
+     unpause to decide whether to dispatch the timer-fiddling work
+     cross-thread. volatile so the publish from the emulator thread is
+     observed without relying on incidental barriers in fuse_init. */
+  NSThread* volatile emulatorThread;
   CFAbsoluteTime time;
   float timerInterval;
 

--- a/fusepb/models/Emulator.m
+++ b/fusepb/models/Emulator.m
@@ -181,6 +181,8 @@ static Emulator *instance = nil;
 
   pool = [[NSAutoreleasePool alloc] init];
 
+  emulatorThread = [[NSThread currentThread] retain];
+
   serverConnection = [NSConnection
                       connectionWithReceivePort:[portArray objectAtIndex:0]
                       sendPort:[portArray objectAtIndex:1]];
@@ -206,6 +208,9 @@ static Emulator *instance = nil;
   [serverConnection invalidate];
 
   fuse_end();
+
+  [emulatorThread release];
+  emulatorThread = nil;
 
   instance = nil;
   [pool release];
@@ -386,18 +391,36 @@ static Emulator *instance = nil;
 
   if( isPaused++ ) return;
 
-  if( timer != nil ) {
+  if( emulatorThread == nil || [NSThread currentThread] == emulatorThread ) {
     [self stopEmulationTimer];
+  } else {
+    [self performSelector:@selector(stopEmulationTimer)
+                 onThread:emulatorThread
+               withObject:nil
+            waitUntilDone:NO];
   }
 }
 
 -(void) unpause
 {
+  /* Underflow guard: isPaused and fuse_emulation_paused must track the
+     same number of holds. A missing teardown hook should surface as a
+     stuck pause rather than walking both counters into negative
+     territory. */
+  if( isPaused <= 0 ) return;
+
   fuse_emulation_unpause();
 
   if( --isPaused ) return;
 
-  [self startEmulationTimer];
+  if( emulatorThread == nil || [NSThread currentThread] == emulatorThread ) {
+    [self startEmulationTimer];
+  } else {
+    [self performSelector:@selector(startEmulationTimer)
+                 onThread:emulatorThread
+               withObject:nil
+            waitUntilDone:NO];
+  }
 }
 
 -(void) reset
@@ -774,9 +797,13 @@ static Emulator *instance = nil;
 -(void) startEmulationTimer
 {
   if( timer == nil ) {
-    timer = [[NSTimer scheduledTimerWithTimeInterval: timerInterval
-                      target:self selector:@selector(updateEmulation:)
-                      userInfo:self repeats:true] retain];
+    timer = [NSTimer timerWithTimeInterval:timerInterval
+                                   target:self
+                                 selector:@selector(updateEmulation:)
+                                 userInfo:self
+                                  repeats:YES];
+    [[NSRunLoop currentRunLoop] addTimer:timer forMode:NSRunLoopCommonModes];
+    [timer retain];
   }
 }
 

--- a/fusepb/views/DisplayOpenGLView.h
+++ b/fusepb/views/DisplayOpenGLView.h
@@ -248,3 +248,18 @@
 -(void) doReshape;
 
 @end
+
+/* Helper category used by every utility controller in §Affected Windows
+   (spec 004) to pin its panel to a parent window and reverse that
+   relationship at teardown. Centralizing the reconciliation removes
+   the previously-duplicated 7-line block in seven controllers. */
+@interface NSWindow (FuseChildPinning)
+/* Make `self` a child window of `parent` with NSWindowAbove ordering.
+   If `self` is already a child of `parent`, this is a no-op. If `self`
+   has a different parent, it is detached first. Passing `nil` or
+   `self` for `parent` is a no-op. */
+- (void)pinAsChildOf:(NSWindow *)parent;
+/* Remove `self` from whatever parent it currently has. No-op if there
+   is no parent. */
+- (void)unpinFromParent;
+@end

--- a/fusepb/views/DisplayOpenGLView.m
+++ b/fusepb/views/DisplayOpenGLView.m
@@ -177,7 +177,6 @@ static DisplayOpenGLView *instance = nil;
   [view_lock lock];
   statusbar_updated = YES;
   [view_lock unlock];
-  [[FuseController singleton] releaseCmdKeys:@"f" withCode:QZ_f];
 }
 
 -(IBAction) zoom:(id)sender
@@ -188,33 +187,27 @@ static DisplayOpenGLView *instance = nil;
   case 1: /* 320x240 */
     size.width = 320;
     size.height = 240;
-    [[FuseController singleton] releaseCmdKeys:@"1" withCode:QZ_1];
     break;
   case 2: /* 640x480 */
     size.width = 640;
     size.height = 480;
-    [[FuseController singleton] releaseCmdKeys:@"2" withCode:QZ_2];
     break;
   case 3: /* 960x720 */
     size.width = 960;
     size.height = 720;
-    [[FuseController singleton] releaseCmdKeys:@"3" withCode:QZ_3];
     break;
   case 4: /* 1280x960 */
     size.width = 1280;
     size.height = 960;
-    [[FuseController singleton] releaseCmdKeys:@"4" withCode:QZ_4];
     break;
   case 5: /* 1600x1200 */
     size.width = 1600;
     size.height = 1200;
-    [[FuseController singleton] releaseCmdKeys:@"5" withCode:QZ_5];
     break;
   case 0:
   default: /* Actual size */
     size.width = screenTex[0].image_width;
     size.height = screenTex[0].image_height;
-    [[FuseController singleton] releaseCmdKeys:@"0" withCode:QZ_0];
   }
 
   [[self window] setContentSize:size];
@@ -1467,11 +1460,6 @@ static DisplayOpenGLView *instance = nil;
   }
 }
 
--(void) windowDidDeminiaturize:(NSNotification *)inNotification
-{
-  [[FuseController singleton] releaseCmdKeys:@"m" withCode:QZ_m];
-}
-
 -(void) displayLinkStop
 {
   if( displayLinkRunning == YES ) {
@@ -1491,6 +1479,29 @@ static DisplayOpenGLView *instance = nil;
       NSLog( @"error starting displayLink:%d", error );
     }
     displayLinkRunning = YES;
+  }
+}
+
+@end
+
+@implementation NSWindow (FuseChildPinning)
+
+- (void)pinAsChildOf:(NSWindow *)parent
+{
+  if( !parent || parent == self ) return;
+  NSWindow *currentParent = [self parentWindow];
+  if( currentParent == parent ) return;
+  if( currentParent ) {
+    [currentParent removeChildWindow:self];
+  }
+  [parent addChildWindow:self ordered:NSWindowAbove];
+}
+
+- (void)unpinFromParent
+{
+  NSWindow *parent = [self parentWindow];
+  if( parent ) {
+    [parent removeChildWindow:self];
   }
 }
 

--- a/fusepb/xibs/MainMenu.xib
+++ b/fusepb/xibs/MainMenu.xib
@@ -220,6 +220,32 @@
                         </items>
                     </menu>
                 </menuItem>
+                <menuItem title="Edit" id="1196">
+                    <menu key="submenu" title="Edit" id="1197">
+                        <items>
+                            <menuItem title="Cut" keyEquivalent="x" id="1198">
+                                <connections>
+                                    <action selector="cut:" target="-1" id="1199"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Copy" keyEquivalent="c" id="1200">
+                                <connections>
+                                    <action selector="copy:" target="-1" id="1201"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Paste" keyEquivalent="v" id="1202">
+                                <connections>
+                                    <action selector="paste:" target="-1" id="1203"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Select All" keyEquivalent="a" id="1204">
+                                <connections>
+                                    <action selector="selectAll:" target="-1" id="1205"/>
+                                </connections>
+                            </menuItem>
+                        </items>
+                    </menu>
+                </menuItem>
                 <menuItem title="View" id="887">
                     <menu key="submenu" title="View" id="888">
                         <items>

--- a/fusepb/xibs/PokeMemory.xib
+++ b/fusepb/xibs/PokeMemory.xib
@@ -14,7 +14,7 @@
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application"/>
         <arrayController id="18" userLabel="Pokes"/>
-        <window title="POKEs/Cheats" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" oneShot="NO" frameAutosaveName="PokeMemory" animationBehavior="default" id="1" userLabel="PokeMem" customClass="NSPanel">
+        <window title="POKEs/Cheats" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" oneShot="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="PokeMemory" animationBehavior="default" id="1" userLabel="PokeMem" customClass="NSPanel">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="196" y="240" width="480" height="270"/>


### PR DESCRIPTION
### Problems solved

- Modal utility dialogs froze the rest of the UI — you couldn't, e.g., keep the Memory Browser open while inspecting registers in the Debugger.
- Cmd+C/V didn't work in the debugger entry field.

The above issues do not exist in the GTK version.

### What this PR does

- Every utility window (Debugger, Memory Browser, Poke Finder, POKEs/Cheats, Save/Load Binary, Rollback, Preferences, Joystick) is now non-blocking. Multiple inspectors can be open at once; clicks on the main window aren't blocked.
- Utility windows stay above the main emulator window inside FuseX, but follow it across apps — Cmd-Tab away and they go too. They no longer hover above other apps' windows.
- The Debugger still surfaces unprompted on a breakpoint even if the user has Cmd-Tabbed away or minimized the main window: it activates FuseX and restores the main window before it appears.
- Cmd+C / Cmd+V / Cmd+X / Cmd+A now work inside the debugger entry field.
- The debugger no longer disappears when FuseX loses focus.

### Defects exposed by removing runModal

Three latent bugs were unreachable while modal sessions serialized utility-window visibility and blocked Cmd+Q; the architecture change made them reproducible, and they are fixed in this PR:

- **Shared `notificationObserver` storage between Memory Browser and Poke Memory.** Both translation units declared the variable at file scope without `static`, so the linker merged them into one slot. With the windows now able to coexist, opening MB then PM and closing MB first caused MB's close block to remove PM's observer, leaking the pause counter on PM's close.
- **Joystick red-X dismissal leaked its parent-child relationship.** Teardown lived only in `-cancel:`; red-X and the Preferences-close cascade skipped it. Reconciled lazily on the next `showWindow:` before, now handled uniformly via a `WillClose` observer.
- **Cmd+Q with Preferences open segfaulted.** `PreferencesController.handleWillClose:` does substantial work (`read_config_file`, machine reselection, scaler hotswap, ROM controller teardown) that reaches into NSWindow's observer table while it is still being walked by the terminate cascade. Now short-circuited via an `NSApplicationWillTerminateNotification` flag; the apply-back path is meaningless at exit.

One independent defect was also fixed in passing:

- **Pokes/Cheats didn't pause the emulator on first open.** `PokeMemory.xib` was missing `visibleAtLaunch="NO"`, so the lazy xib load that happens during init ordered the window front before `showWindow:` ran; the early-return guard in `showWindow:` then skipped the pause, while the close block still unpaused. Each cycle walked the counter down by one, eventually breaking pause for every utility window until the next app launch.

### Tests

Manual, AppleScript-driven against an installed build:

- Single-step advances the PC by exactly one instruction across consecutive clicks.
- Many break/continue cycles in a row, no deadlock.
- Joystick stays above Preferences even when the parent is explicitly raised.
- With FuseX in the background and its main window minimized, triggering the Debugger surfaces both.
- Switching from FuseX to another app sinks every utility window with FuseX; switching back rises them together with z-order preserved.
- Open Memory Browser, then Poke Memory, close Memory Browser first, then Poke Memory — pause counter returns to zero.
- Open Pokes/Cheats from a clean launch — emulator pauses; close it — emulator resumes. Subsequent utility windows still pause correctly.
- Dismiss Joystick via the red X (not Apply/Cancel) — parent-child link is cleaned up; reopening works.
- Quit FuseX with Preferences open — clean exit, no crash.
