### PR TITLE
Skip joystick reinit when joystick settings unchanged

### DIFF
--- a/fusepb/controllers/PreferencesController.m
+++ b/fusepb/controllers/PreferencesController.m
@@ -205,6 +205,8 @@
   [[NSNotificationCenter defaultCenter] removeObserver:self];
 
   int old_bilinear = settings_current.bilinear_filter;
+  int old_joy1_number = settings_current.joy1_number;
+  int old_joy2_number = settings_current.joy2_number;
 
   /* Values in shared defaults have been updated, pass them onto Fuse */
   read_config_file( &settings_current );
@@ -226,8 +228,12 @@
 
   settings_get_rom_array( &settings_current, machineRoms );
 
-  joystick_end();
-  joystick_init( NULL );
+  int joystick_changed = old_joy1_number != settings_current.joy1_number ||
+                         old_joy2_number != settings_current.joy2_number;
+  if( joystick_changed ) {
+    joystick_end();
+    joystick_init( NULL );
+  }
 
   {
     NSArray *romURLs = [Emulator beginROMScopedAccess];


### PR DESCRIPTION
### Problem

Closing the Preferences window causes a ~1 second UI freeze regardless of what settings were changed. The freeze is caused by `SDL_JoystickQuit` + `SDL_JoystickInit` running unconditionally on every close, triggering SDL device enumeration even when no joystick settings were touched.

### What this PR does

Snapshots the four joystick-relevant settings before `read_config_file` reads new values from `NSUserDefaults`, then only calls `joystick_end`/`joystick_init` when at least one of them changed.