### PR TITLE
Fix Graphics Filter preferences bugs

### DIFF
--- a/fusepb/FuseX.xcodeproj/project.pbxproj
+++ b/fusepb/FuseX.xcodeproj/project.pbxproj
@@ -119,6 +119,7 @@
 		B61F468B09121DF100C8096C /* PreferencesController.m in Sources */ = {isa = PBXBuildFile; fileRef = B650F73F07E7CD3F00E4F3AF /* PreferencesController.m */; };
 		B61F468C09121DF100C8096C /* ScalerNameToIdTransformer.m in Sources */ = {isa = PBXBuildFile; fileRef = B67F3C1507ED1C9D0045339F /* ScalerNameToIdTransformer.m */; };
 		B61F468D09121DF100C8096C /* MachineScalerIsEnabled.m in Sources */ = {isa = PBXBuildFile; fileRef = B67F3C5007ED34530045339F /* MachineScalerIsEnabled.m */; };
+		B61F46A009121DF100C8096C /* ScalerSupportsScanlines.m in Sources */ = {isa = PBXBuildFile; fileRef = B67F3D0107ED1C9D0045339F /* ScalerSupportsScanlines.m */; };
 		B61F468E09121DF100C8096C /* MachineNameToIdTransformer.m in Sources */ = {isa = PBXBuildFile; fileRef = B67F3CC407EE0A130045339F /* MachineNameToIdTransformer.m */; };
 		B61F468F09121DF100C8096C /* CAMachines.m in Sources */ = {isa = PBXBuildFile; fileRef = B6CC83000800E408006EFFB9 /* CAMachines.m */; };
 		B61F469009121DF100C8096C /* Joysticks.m in Sources */ = {isa = PBXBuildFile; fileRef = B6C740DA0810BB0500AB170C /* Joysticks.m */; };
@@ -562,6 +563,8 @@
 		B67DC2180B63835100FA31B6 /* cocoastatusbar.m */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.objc; path = cocoastatusbar.m; sourceTree = "<group>"; };
 		B67F3C1407ED1C9D0045339F /* ScalerNameToIdTransformer.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = ScalerNameToIdTransformer.h; path = transformers/ScalerNameToIdTransformer.h; sourceTree = SOURCE_ROOT; };
 		B67F3C1507ED1C9D0045339F /* ScalerNameToIdTransformer.m */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.objc; name = ScalerNameToIdTransformer.m; path = transformers/ScalerNameToIdTransformer.m; sourceTree = SOURCE_ROOT; };
+		B67F3D0007ED1C9D0045339F /* ScalerSupportsScanlines.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = ScalerSupportsScanlines.h; path = transformers/ScalerSupportsScanlines.h; sourceTree = SOURCE_ROOT; };
+		B67F3D0107ED1C9D0045339F /* ScalerSupportsScanlines.m */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.objc; name = ScalerSupportsScanlines.m; path = transformers/ScalerSupportsScanlines.m; sourceTree = SOURCE_ROOT; };
 		B67F3C4F07ED34530045339F /* MachineScalerIsEnabled.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = MachineScalerIsEnabled.h; path = transformers/MachineScalerIsEnabled.h; sourceTree = SOURCE_ROOT; };
 		B67F3C5007ED34530045339F /* MachineScalerIsEnabled.m */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.objc; name = MachineScalerIsEnabled.m; path = transformers/MachineScalerIsEnabled.m; sourceTree = SOURCE_ROOT; };
 		B67F3CC307EE0A130045339F /* MachineNameToIdTransformer.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = MachineNameToIdTransformer.h; path = transformers/MachineNameToIdTransformer.h; sourceTree = SOURCE_ROOT; };
@@ -1260,6 +1263,8 @@
 				B67F3C5007ED34530045339F /* MachineScalerIsEnabled.m */,
 				B67F3C1407ED1C9D0045339F /* ScalerNameToIdTransformer.h */,
 				B67F3C1507ED1C9D0045339F /* ScalerNameToIdTransformer.m */,
+				B67F3D0007ED1C9D0045339F /* ScalerSupportsScanlines.h */,
+				B67F3D0107ED1C9D0045339F /* ScalerSupportsScanlines.m */,
 				B66D6C9608115FC200FAE6F3 /* VolumeSliderToPrefTransformer.h */,
 				B66D6C9708115FC200FAE6F3 /* VolumeSliderToPrefTransformer.m */,
 			);
@@ -2093,6 +2098,7 @@
 				B61F468B09121DF100C8096C /* PreferencesController.m in Sources */,
 				B61F468C09121DF100C8096C /* ScalerNameToIdTransformer.m in Sources */,
 				B61F468D09121DF100C8096C /* MachineScalerIsEnabled.m in Sources */,
+				B61F46A009121DF100C8096C /* ScalerSupportsScanlines.m in Sources */,
 				B61F468E09121DF100C8096C /* MachineNameToIdTransformer.m in Sources */,
 				B61F468F09121DF100C8096C /* CAMachines.m in Sources */,
 				B61F469009121DF100C8096C /* Joysticks.m in Sources */,

--- a/fusepb/controllers/PreferencesController.h
+++ b/fusepb/controllers/PreferencesController.h
@@ -48,6 +48,7 @@
   IBOutlet NSView *machinePrefsView;
   IBOutlet NSView *filterPrefsView;
   IBOutlet NSView *debuggerPrefsView;
+  IBOutlet NSButton *bilinearCheckbox;
 
   JoystickConfigurationController *joystickConfigurationController;
 

--- a/fusepb/controllers/PreferencesController.m
+++ b/fusepb/controllers/PreferencesController.m
@@ -38,6 +38,7 @@
 #import "HIDJoysticks.h"
 
 #import "ScalerNameToIdTransformer.h"
+#import "ScalerSupportsScanlines.h"
 #import "MachineScalerIsEnabled.h"
 #import "MachineNameToIdTransformer.h"
 #import "VolumeSliderToPrefTransformer.h"
@@ -62,6 +63,7 @@
 +(void) initialize
 {
   ScalerNameToIdTransformer *sNToITransformer;
+  ScalerSupportsScanlines *scalerSupportsScanlines;
   MachineScalerIsEnabled *machineScalerIsEnabled;
   MachineNameToIdTransformer *mToITransformer;
   VolumeSliderToPrefTransformer *vsToPTransformer;
@@ -70,6 +72,11 @@
 
   [NSValueTransformer setValueTransformer:sNToITransformer
                                   forName:@"ScalerNameToIdTransformer"];
+
+  scalerSupportsScanlines = [[[ScalerSupportsScanlines alloc] init] autorelease];
+
+  [NSValueTransformer setValueTransformer:scalerSupportsScanlines
+                                  forName:@"ScalerSupportsScanlines"];
 
   machineScalerIsEnabled = [MachineScalerIsEnabled
                                 machineScalerIsEnabledWithInt:1];

--- a/fusepb/controllers/PreferencesController.m
+++ b/fusepb/controllers/PreferencesController.m
@@ -99,6 +99,12 @@
 
   [NSValueTransformer setValueTransformer:vsToPTransformer
                                   forName:@"VolumeSliderToPrefTransformer"];
+
+  /* Force the saved bilinear flag off so the disabled Bilinear checkbox
+     shows as unchecked rather than checked-but-greyed for users upgrading
+     from a build where they had enabled it. Drop this when the TODO in
+     DisplayOpenGLView.m re-enables the setting. */
+  [[NSUserDefaults standardUserDefaults] setBool:NO forKey:@"bilinear"];
 }
 
 - (void)windowDidLoad 
@@ -145,6 +151,12 @@
   NSToolbarItem *item = [[toolbar items] objectAtIndex:[defaults integerForKey:@"preferencestab"]];
   [toolbar setSelectedItemIdentifier:[item itemIdentifier]];
   [self selectPrefPanel:item];
+
+  /* The xib's static enabled="NO" attribute is silently dropped by ibtool
+     for buttons with a value binding (the compiled nib has NSEnabled=true),
+     so disable it here instead. Drop this when the TODO in
+     DisplayOpenGLView.m re-enables bilinear filtering. */
+  [bilinearCheckbox setEnabled:NO];
 }
 
 - (void)showWindow:(id)sender

--- a/fusepb/controllers/PreferencesController.m
+++ b/fusepb/controllers/PreferencesController.m
@@ -218,8 +218,25 @@
   // B&W TV status may have changed
   display_refresh_all();
 
-  if( ( ( current_scaler != scaler_get_type(settings_current.start_scaler_mode) )
-          && !scaler_select_id(settings_current.start_scaler_mode) ) ||
+  scaler_type prev_scaler = current_scaler;
+
+  /* Skip silently for unknown ids (e.g. defaults written by an older build
+     with a now-removed scaler) rather than show ui_error from
+     scaler_select_id every time Preferences closes. */
+  int new_scaler = scaler_get_type( settings_current.start_scaler_mode );
+  if( new_scaler >= 0 ) {
+    /* scaler_select_scaler is a no-op when the requested scaler is already
+       current; if it isn't supported on the current machine it returns
+       non-zero and current_scaler is left unchanged. When the scaler does
+       change, the hotswap inside picks up the new bilinear setting via
+       createTexture, so no separate hotswap call is needed for that path. */
+    scaler_select_scaler( new_scaler );
+  }
+
+  /* For bilinear-only changes, the hotswap inside scaler_select_scaler
+     didn't fire; trigger one explicitly so createTexture picks up the new
+     filter. */
+  if( current_scaler == prev_scaler &&
       old_bilinear != settings_current.bilinear_filter ) {
     uidisplay_hotswap_gfx_mode();
   }

--- a/fusepb/transformers/ScalerSupportsScanlines.h
+++ b/fusepb/transformers/ScalerSupportsScanlines.h
@@ -1,0 +1,28 @@
+/* ScalerSupportsScanlines.h: Transformer that returns YES when the selected
+                               graphics filter supports the PAL TV scanlines
+                               option
+   Copyright (c) 2026 The FuseX Authors
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+
+*/
+
+#import <Foundation/Foundation.h>
+
+@interface ScalerSupportsScanlines : NSValueTransformer
++ (Class)transformedValueClass;
++ (BOOL)allowsReverseTransformation;
+- (id)transformedValue:(id)value;
+@end

--- a/fusepb/transformers/ScalerSupportsScanlines.m
+++ b/fusepb/transformers/ScalerSupportsScanlines.m
@@ -1,0 +1,65 @@
+/* ScalerSupportsScanlines.m: Transformer that returns YES when the selected
+                               graphics filter supports the PAL TV scanlines
+                               option
+   Copyright (c) 2026 The FuseX Authors
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+
+*/
+
+#import "ScalerSupportsScanlines.h"
+
+#include "ui/scaler/scaler.h"
+
+@implementation ScalerSupportsScanlines
+
++ (Class)transformedValueClass
+{
+  return [NSNumber class];
+}
+
++ (BOOL)allowsReverseTransformation
+{
+  return NO;
+}
+
+- (id)transformedValue:(id)value
+{
+  const char *id_string;
+
+  if( value == nil ) return @(NO);
+
+  if( [value respondsToSelector:@selector(UTF8String)] ) {
+    /* handles NSString */
+    id_string = [value UTF8String];
+  } else if( [value respondsToSelector:@selector(stringValue)] ) {
+    /* handles NSCell and NSNumber */
+    id_string = [[value stringValue] UTF8String];
+  } else {
+    /* unexpected type (e.g. NSNull from a corrupt defaults entry); leave
+       the checkbox disabled rather than raise from a binding evaluation */
+    return @(NO);
+  }
+
+  /* Only PAL TV 2x, 3x and 4x expose a scanlines option; the 1x variant
+     has no alternate row to darken */
+  int type = scaler_get_type( id_string );
+  BOOL supports = type == SCALER_PALTV2X ||
+                  type == SCALER_PALTV3X ||
+                  type == SCALER_PALTV4X;
+  return @(supports);
+}
+
+@end

--- a/fusepb/views/DisplayOpenGLView.m
+++ b/fusepb/views/DisplayOpenGLView.m
@@ -688,7 +688,12 @@ static DisplayOpenGLView *instance = nil;
                      GL_STORAGE_CACHED_APPLE );
     glPixelStorei( GL_UNPACK_CLIENT_STORAGE_APPLE, GL_TRUE );
 #endif
-    GLint filter = settings_current.bilinear_filter ? GL_LINEAR : GL_NEAREST;
+    /* TODO: honour settings_current.bilinear_filter again and re-enable the
+       Bilinear checkbox in PreferencesController -awakeFromNib once
+       bilinear filtering is fully working. Hard-coded to nearest-neighbour
+       for now so the broken path is not reached for users with the setting
+       saved on. */
+    GLint filter = GL_NEAREST;
     glTexParameteri( GL_TEXTURE_RECTANGLE_ARB, GL_TEXTURE_MIN_FILTER, filter );
     glTexParameteri( GL_TEXTURE_RECTANGLE_ARB, GL_TEXTURE_MAG_FILTER, filter );
     glTexParameteri( GL_TEXTURE_RECTANGLE_ARB, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE );

--- a/fusepb/xibs/Preferences.xib
+++ b/fusepb/xibs/Preferences.xib
@@ -1901,6 +1901,11 @@
                     </buttonCell>
                     <connections>
                         <binding destination="270" name="value" keyPath="values.paltv2x" id="1743"/>
+                        <binding destination="270" name="enabled" keyPath="values.graphicsfilter" id="1790">
+                            <dictionary key="options">
+                                <string key="NSValueTransformerName">ScalerSupportsScanlines</string>
+                            </dictionary>
+                        </binding>
                     </connections>
                 </button>
                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1717">

--- a/fusepb/xibs/Preferences.xib
+++ b/fusepb/xibs/Preferences.xib
@@ -22,6 +22,7 @@
                 <outlet property="rom1Filename" destination="1627" id="1783"/>
                 <outlet property="rom2Filename" destination="1629" id="1784"/>
                 <outlet property="rom3Filename" destination="1626" id="1785"/>
+                <outlet property="bilinearCheckbox" destination="1717" id="1789"/>
                 <outlet property="romPrefsView" destination="1582" id="1778"/>
                 <outlet property="rzxPrefsView" destination="1488" id="1779"/>
                 <outlet property="soundPrefsView" destination="1408" id="1780"/>

--- a/fusepb/xibs/Preferences.xib
+++ b/fusepb/xibs/Preferences.xib
@@ -2023,9 +2023,16 @@
                                     </binding>
                                 </connections>
                             </buttonCell>
-                            <buttonCell type="radio" title="HQ 4x" imagePosition="left" alignment="left" tag="24" inset="2" id="tRv-o9-mGu">
+                            <buttonCell type="radio" title="TV 4x" imagePosition="left" alignment="left" tag="13" inset="2" id="1721">
                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                 <font key="font" metaFont="system"/>
+                                <connections>
+                                    <binding destination="270" name="enabled" keyPath="values.machine" id="1791">
+                                        <dictionary key="options">
+                                            <string key="NSValueTransformerName">MachineTimexIsDisabled</string>
+                                        </dictionary>
+                                    </binding>
+                                </connections>
                             </buttonCell>
                         </column>
                         <column>
@@ -2066,6 +2073,17 @@
                                     </binding>
                                 </connections>
                             </buttonCell>
+                            <buttonCell type="radio" title="PAL TV 4x" imagePosition="left" alignment="left" tag="21" inset="2" id="74h-R3-Dsl">
+                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                <font key="font" metaFont="system"/>
+                                <connections>
+                                    <binding destination="270" name="enabled" keyPath="values.machine" id="1792">
+                                        <dictionary key="options">
+                                            <string key="NSValueTransformerName">MachineTimexIsDisabled</string>
+                                        </dictionary>
+                                    </binding>
+                                </connections>
+                            </buttonCell>
                             <buttonCell type="radio" title="HQ 2x" imagePosition="left" alignment="left" tag="22" inset="2" id="1729">
                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                 <font key="font" metaFont="system"/>
@@ -2088,6 +2106,17 @@
                                     </binding>
                                 </connections>
                             </buttonCell>
+                            <buttonCell type="radio" title="HQ 4x" imagePosition="left" alignment="left" tag="24" inset="2" id="tRv-o9-mGu">
+                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                <font key="font" metaFont="system"/>
+                                <connections>
+                                    <binding destination="270" name="enabled" keyPath="values.machine" id="1793">
+                                        <dictionary key="options">
+                                            <string key="NSValueTransformerName">MachineTimexIsDisabled</string>
+                                        </dictionary>
+                                    </binding>
+                                </connections>
+                            </buttonCell>
                             <buttonCell type="radio" title="Dot Matrix" imagePosition="left" alignment="left" tag="15" inset="2" id="1725">
                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                 <font key="font" metaFont="system"/>
@@ -2098,14 +2127,6 @@
                                         </dictionary>
                                     </binding>
                                 </connections>
-                            </buttonCell>
-                            <buttonCell type="radio" title="TV 4x" imagePosition="left" alignment="left" tag="13" inset="2" id="1721">
-                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                                <font key="font" metaFont="system"/>
-                            </buttonCell>
-                            <buttonCell type="radio" title="PAL TV 4x" imagePosition="left" alignment="left" tag="21" inset="2" id="74h-R3-Dsl">
-                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                                <font key="font" metaFont="system"/>
                             </buttonCell>
                         </column>
                     </cells>

--- a/ui/cocoa/cocoadisplay.m
+++ b/ui/cocoa/cocoadisplay.m
@@ -229,6 +229,46 @@ cocoadisplay_allocate_colours( int numColours, uint16_t *colour_values,
   }
 }
 
+/* Resize the emulator window to match the unscaled framebuffer (set by
+   uidisplay_init from per-machine dimensions) times the current scaler
+   factor. Mirrors gtkdisplay_load_gfx_mode's gtk_window_resize call.
+
+   Callers may be on a worker thread (fuse_init runs on the emulator thread
+   spawned by -[Emulator connectWithPorts:]) or the main thread
+   (Preferences close). NSWindow geometry must be touched on the main
+   thread, so dispatch unconditionally to it; the size is captured by the
+   block to avoid reading shared state on the wrong thread. */
+static void
+cocoadisplay_resize_window( void )
+{
+  /* Skip during the very first uidisplay_init so the xib's window size is
+     preserved at launch. Subsequent inits (machine change) and every
+     hotswap will resize. */
+  if( !display_ui_initialised || settings_current.full_screen ) return;
+
+  float factor = scaler_get_scaling_factor( current_scaler );
+  NSSize size = NSMakeSize( image_width * factor, image_height * factor );
+
+  dispatch_async( dispatch_get_main_queue(), ^{
+    /* Re-check after the hop in case the user entered fullscreen between
+       enqueue and execute. */
+    if( settings_current.full_screen ) return;
+
+    /* Preserve the window's perceived centre; setContentSize: would anchor
+       the top-left and drift the centre across repeated scaler changes. */
+    NSWindow *win = [[DisplayOpenGLView instance] window];
+    NSRect old = [win frame];
+    NSRect frame = [win frameRectForContentRect:
+                            NSMakeRect( 0, 0, size.width, size.height )];
+    frame.origin.x = NSMidX( old ) - frame.size.width / 2.0;
+    frame.origin.y = NSMidY( old ) - frame.size.height / 2.0;
+    /* A 4x scaler from a corner-positioned window can otherwise push the
+       title bar off-screen and make the window hard to recover. */
+    frame = [win constrainFrameRect:frame toScreen:[win screen]];
+    [win setFrame:frame display:YES animate:YES];
+  });
+}
+
 int
 uidisplay_init( int width, int height )
 {
@@ -247,6 +287,8 @@ uidisplay_init( int width, int height )
   cocoadisplay_load_gfx_mode();
   [buffered_screen_lock unlock];
 
+  cocoadisplay_resize_window();
+
   /* We can now output error messages to our output device */
   display_ui_initialised = 1;
 
@@ -261,6 +303,27 @@ uidisplay_hotswap_gfx_mode( void )
   /* obtain lock for buffered screen */
   [buffered_screen_lock lock];
 
+  /* Preserve last rendered pixel data so we can repopulate the new surfaces
+     after reallocation, avoiding a black frame during a scaler-only swap.
+     (A swap that follows a machine change still flashes black for one frame
+     because uidisplay_init has just zeroed unscaled_screen.pixels and no
+     emulator frame has run yet.)
+     pixels is NULL on the very first hotswap (before uidisplay_init has run
+     load_gfx_mode) and after uidisplay_end, so the NULL check covers
+     "no valid frame yet". */
+  uint16_t *saved_pixels = NULL;
+  size_t saved_pixels_size = 0;
+  if( unscaled_screen.pixels ) {
+    size_t bytes = (size_t)unscaled_screen.full_width *
+                   unscaled_screen.full_height *
+                   sizeof(uint16_t);
+    saved_pixels = malloc( bytes );
+    if( saved_pixels ) {
+      memcpy( saved_pixels, unscaled_screen.pixels, bytes );
+      saved_pixels_size = bytes;
+    }
+  }
+
   /* Free the old surfaces */
   free_screen( &unscaled_screen );
   free_screen( &scaled_screen );
@@ -269,10 +332,52 @@ uidisplay_hotswap_gfx_mode( void )
   /* Setup the new GFX mode */
   cocoadisplay_load_gfx_mode();
 
+  /* Repopulate the new surfaces under the lock so the display link sees a
+     valid frame the moment the lock is released. Inlines the equivalent of
+     uidisplay_area + uidisplay_frame_end without re-acquiring the lock
+     (NSLock is non-recursive). Skip the restore if the new surface size
+     differs from the saved buffer to avoid a buffer overrun. */
+  if( saved_pixels && unscaled_screen.pixels &&
+      saved_pixels_size == (size_t)unscaled_screen.full_width *
+                           unscaled_screen.full_height *
+                           sizeof(uint16_t) ) {
+    int i;
+    PIG_rect r = { 0, 0, image_width, image_height };
+
+    memcpy( unscaled_screen.pixels, saved_pixels, saved_pixels_size );
+
+    if( current_scaler == SCALER_NORMAL ) {
+      pig_dirty_add( unscaled_screen.dirty, &r );
+    } else {
+      r.w = display_current_size * image_width;
+      r.h = display_current_size * image_height;
+      pig_dirty_add( scaled_screen.dirty, &r );
+      scaler_proc16( unscaled_screen.pixels +
+                       unscaled_screen.image_yoffset * unscaled_screen.pitch +
+                       sizeof(uint16_t) * unscaled_screen.image_xoffset,
+                     unscaled_screen.pitch,
+                     scaled_screen.pixels +
+                       scaled_screen.image_yoffset * scaled_screen.pitch +
+                       sizeof(uint16_t) * scaled_screen.image_xoffset,
+                     scaled_screen.pitch, image_width, image_height );
+    }
+
+    for( i = 0; i < screen->dirty->count; ++i )
+      copy_area( &buffered_screen, screen, screen->dirty->rects + i );
+    pig_dirty_merge( buffered_screen.dirty, screen->dirty );
+
+    unscaled_screen.dirty->count = 0;
+    if( current_scaler != SCALER_NORMAL ) scaled_screen.dirty->count = 0;
+  }
+
   [buffered_screen_lock unlock];
 
+  free( saved_pixels );
+
+  cocoadisplay_resize_window();
+
   fuse_emulation_unpause();
-  
+
   return 0;
 }
 


### PR DESCRIPTION
### Problems solved

1. Switching the graphics filter in Preferences didn't resize the emulator window to the new scale factor.
2. The PAL TV scanlines checkbox was always enabled, even for scalers without scanlines.
3. Scaler radio buttons weren't grouped by family (TV, PAL TV, HQ), making the panel hard to scan.
4. The Bilinear checkbox did nothing — `GL_TEXTURE_RECTANGLE_ARB` silently ignores `GL_LINEAR`.

### What this PR does

One commit per problem. The window resize lives in `cocoadisplay_resize_window` (`ui/cocoa/cocoadisplay.m`), fired from `uidisplay_init` and `uidisplay_hotswap_gfx_mode` and gated on `display_ui_initialised` so the xib's saved size wins on first launch. The hotswap also captures and re-applies the unscaled pixel buffer across the surface reallocation to avoid a black flash; `uidisplay_area`/`uidisplay_frame_end` are inlined because `NSLock` is non-recursive.

### Tradeoffs

- Bilinear is hard-disabled in three places but the binding and hotswap scaffolding are left in — small amount of dead-looking code now buys a four-line re-enable later.

### The new look
<img width="941" height="396" alt="preferences" src="https://github.com/user-attachments/assets/c9de90f5-b9f9-4682-aa8b-94d84f9b8498" />

