### PR TITLE
Unify fullscreen around AppKit native transition

### DIFF
--- a/fusepb/controllers/FuseController.h
+++ b/fusepb/controllers/FuseController.h
@@ -95,7 +95,6 @@
 - (IBAction)cart_eject:(id)sender;
 - (IBAction)cart_open:(id)sender;
 - (IBAction)export_screen:(id)sender;
-- (IBAction)fullscreen:(id)sender;
 - (IBAction)hard_reset:(id)sender;
 - (IBAction)ide_commit:(id)sender;
 - (IBAction)ide_eject:(id)sender;

--- a/fusepb/controllers/FuseController.m
+++ b/fusepb/controllers/FuseController.m
@@ -1015,11 +1015,6 @@ save_as_exit:
   [[DisplayOpenGLView instance] settingsSave];
 }
 
-- (IBAction)fullscreen:(id)sender
-{
-  [[DisplayOpenGLView instance] fullscreen];
-}
-
 - (IBAction)hard_reset:(id)sender
 {
   [[DisplayOpenGLView instance] pause];

--- a/fusepb/controllers/FuseController.m
+++ b/fusepb/controllers/FuseController.m
@@ -1150,7 +1150,7 @@ save_as_exit:
 
 - (IBAction)quit:(id)sender
 {
-  [[NSApp keyWindow] performClose:self];
+  [NSApp terminate:self];
 }
 
 - (IBAction)hide:(id)sender
@@ -2611,6 +2611,19 @@ save_as_exit:
   [[DisplayOpenGLView instance] unpause];
 
   return confirm;
+}
+
+- (NSApplicationTerminateReply)applicationShouldTerminate:(NSApplication *)sender
+{
+  /* The user-facing prompts live here, not in -windowShouldClose:, so Cmd+Q
+     (-quit: → [NSApp terminate:]) and red-button / Cmd+W (windowShouldClose:
+     → [NSApp terminate:]) share one path. AppKit calls close (not
+     performClose:) on each window during termination, so windowShouldClose:
+     would be bypassed on the Cmd+Q path otherwise. */
+  if( !cocoaui_confirm( "Exit Fuse?" ) ) return NSTerminateCancel;
+  if( [[DisplayOpenGLView instance] checkMediaChanged] ) return NSTerminateCancel;
+  [[DisplayOpenGLView instance] displayLinkStop];
+  return NSTerminateNow;
 }
 
 - (BOOL)applicationShouldTerminateAfterLastWindowClosed:(NSApplication *)theApplication

--- a/fusepb/controllers/FuseController.m
+++ b/fusepb/controllers/FuseController.m
@@ -682,21 +682,19 @@ error:
 {
   char *filename = NULL;
 
-  if( !settings_current.full_screen ) {
-    [[DisplayOpenGLView instance] pause];
-    
-    filename = cocoaui_openpanel_get_filename( @"Open Spectrum File", allFileTypes );
+  [[DisplayOpenGLView instance] pause];
 
-    if( !filename ) { [[DisplayOpenGLView instance] unpause]; return; }
+  filename = cocoaui_openpanel_get_filename( @"Open Spectrum File", allFileTypes );
 
-    [self addRecentSnapshot:filename];
+  if( !filename ) { [[DisplayOpenGLView instance] unpause]; return; }
 
-    [self openFile:filename];
+  [self addRecentSnapshot:filename];
 
-    free(filename);
+  [self openFile:filename];
 
-    [[DisplayOpenGLView instance] unpause];
-  }
+  free(filename);
+
+  [[DisplayOpenGLView instance] unpause];
 }
 
 - (IBAction)reset:(id)sender
@@ -889,22 +887,20 @@ error:
 {
   char *filename = NULL;
 
-  if( !settings_current.full_screen ) {
-    [[DisplayOpenGLView instance] pause];
+  [[DisplayOpenGLView instance] pause];
 
-    filename = cocoaui_savepanel_get_filename( @"Save Snapshot As", @[@"szx", @"z80", @"sna"] );
+  filename = cocoaui_savepanel_get_filename( @"Save Snapshot As", @[@"szx", @"z80", @"sna"] );
 
-    if( !filename ) goto save_as_exit;
+  if( !filename ) goto save_as_exit;
 
-    [[DisplayOpenGLView instance] snapshotWrite:filename];
+  [[DisplayOpenGLView instance] snapshotWrite:filename];
 
-    [self addRecentSnapshot:filename];
+  [self addRecentSnapshot:filename];
 
-    free( filename );
+  free( filename );
 
 save_as_exit:
-    [[DisplayOpenGLView instance] unpause];
-  }
+  [[DisplayOpenGLView instance] unpause];
 }
 
 - (IBAction)open_screen:(id)sender
@@ -1154,9 +1150,7 @@ save_as_exit:
 
 - (IBAction)quit:(id)sender
 {
-  if( !settings_current.full_screen ) {
-    [[NSApp keyWindow] performClose:self];
-  }
+  [[NSApp keyWindow] performClose:self];
 }
 
 - (IBAction)hide:(id)sender
@@ -1166,9 +1160,7 @@ save_as_exit:
 
 - (IBAction)help:(id)sender
 {
-  if( !settings_current.full_screen ) {
-    [NSApp showHelp:self];
-  }
+  [NSApp showHelp:self];
 }
 
 - (IBAction)cocoa_break:(id)sender
@@ -1205,95 +1197,75 @@ save_as_exit:
 
 - (IBAction)showRollbackPane:(id)sender
 {
-  if( !settings_current.full_screen ) {
-    if( !rollbackController ) {
-      rollbackController = [[RollbackController alloc] init];
-    }
-    [rollbackController showWindow:self];
+  if( !rollbackController ) {
+    rollbackController = [[RollbackController alloc] init];
   }
+  [rollbackController showWindow:self];
 }
 
 - (IBAction)showTapeBrowserPane:(id)sender
 {
-  if( !settings_current.full_screen ) {
-    if( !tapeBrowserController ) {
-      tapeBrowserController = [[TapeBrowserController alloc] init];
-    }
-    [tapeBrowserController showWindow:self];
+  if( !tapeBrowserController ) {
+    tapeBrowserController = [[TapeBrowserController alloc] init];
   }
+  [tapeBrowserController showWindow:self];
 }
 
 - (IBAction)showKeyboardPane:(id)sender
 {
-  if( !settings_current.full_screen ) {
-    if( !settings_current.full_screen ) {
-      if( !keyboardController ) {
-        keyboardController = [[KeyboardController alloc] init];
-      }
-      [keyboardController showCloseWindow:self];
-    }
+  if( !keyboardController ) {
+    keyboardController = [[KeyboardController alloc] init];
   }
+  [keyboardController showCloseWindow:self];
 }
 
 - (IBAction)showLoadBinaryPane:(id)sender
 {
-  if( !settings_current.full_screen ) {
-    if( !loadBinaryController ) {
-      loadBinaryController = [[LoadBinaryController alloc] init];
-    }
-
-    [loadBinaryController showWindow:self];
+  if( !loadBinaryController ) {
+    loadBinaryController = [[LoadBinaryController alloc] init];
   }
+
+  [loadBinaryController showWindow:self];
 }
 
 - (IBAction)showSaveBinaryPane:(id)sender
 {
-  if( !settings_current.full_screen ) {
-    if( !saveBinaryController ) {
-      saveBinaryController = [[SaveBinaryController alloc] init];
-    }
-    [saveBinaryController showWindow:self];
+  if( !saveBinaryController ) {
+    saveBinaryController = [[SaveBinaryController alloc] init];
   }
+  [saveBinaryController showWindow:self];
 }
 
 - (IBAction)showPokeFinderPane:(id)sender
 {
-  if( !settings_current.full_screen ) {
-    if( !pokeFinderController ) {
-      pokeFinderController = [[PokeFinderController alloc] init];
-    }
-    [pokeFinderController showWindow:self];
+  if( !pokeFinderController ) {
+    pokeFinderController = [[PokeFinderController alloc] init];
   }
+  [pokeFinderController showWindow:self];
 }
 
 - (IBAction)showPokeMemoryPane:(id)sender
 {
-  if( !settings_current.full_screen ) {
-    if( !pokeMemoryController ) {
-      pokeMemoryController = [[PokeMemoryController alloc] init];
-    }
-    [pokeMemoryController showWindow:self];
+  if( !pokeMemoryController ) {
+    pokeMemoryController = [[PokeMemoryController alloc] init];
   }
+  [pokeMemoryController showWindow:self];
 }
 
 - (IBAction)showMemoryBrowserPane:(id)sender
 {
-  if( !settings_current.full_screen ) {
-    if( !memoryBrowserController ) {
-      memoryBrowserController = [[MemoryBrowserController alloc] init];
-    }
+  if( !memoryBrowserController ) {
+    memoryBrowserController = [[MemoryBrowserController alloc] init];
   }
   [memoryBrowserController showWindow:self];
 }
 
 - (IBAction)showPreferencesPane:(id)sender;
 {
-  if( !settings_current.full_screen ) {
-    if( !preferencesController ) {
-      preferencesController = [[PreferencesController alloc] init];
-    }
-    [preferencesController showWindow:self];
+  if( !preferencesController ) {
+    preferencesController = [[PreferencesController alloc] init];
   }
+  [preferencesController showWindow:self];
 }
 
 - (IBAction)saveFileTypeClicked:(id)sender;

--- a/fusepb/models/Emulator.h
+++ b/fusepb/models/Emulator.h
@@ -112,8 +112,6 @@
 -(void) settingsSave;
 -(void) settingsResetDefaults;
 
--(void) fullscreen;
-
 -(void) joystickToggleKeyboard;
 -(void) keyboardToggleRecreatedZXSpectrum;
 -(void) keyboardToggleArrowsShifted;

--- a/fusepb/models/Emulator.m
+++ b/fusepb/models/Emulator.m
@@ -562,11 +562,6 @@ static Emulator *instance = nil;
   settings_defaults( &settings_current );
 }
 
--(void) fullscreen
-{
-  settings_current.full_screen = 1;
-}
-
 -(void) joystickToggleKeyboard
 {
   settings_current.joy_keyboard = !settings_current.joy_keyboard;

--- a/fusepb/views/DisplayOpenGLView.h
+++ b/fusepb/views/DisplayOpenGLView.h
@@ -64,9 +64,6 @@
 
   NSLock *view_lock;
 
-  NSWindow *fullscreenWindow;
-  NSWindow *windowedWindow;
-
   float target_ratio;
 
   Emulator *real_emulator;
@@ -80,7 +77,6 @@
 }
 +(DisplayOpenGLView *) instance;
 
--(IBAction) fullscreen:(id)sender;
 -(IBAction) zoom:(id)sender;
 
 -(void) createTexture:(Cocoa_Texture*)newScreen;
@@ -139,8 +135,6 @@
 
 -(void) settingsSave;
 -(void) settingsResetDefaults;
-
--(void) fullscreen;
 
 -(void) joystickToggleKeyboard;
 -(void) keyboardToggleRecreatedZXSpectrum;

--- a/fusepb/views/DisplayOpenGLView.m
+++ b/fusepb/views/DisplayOpenGLView.m
@@ -508,20 +508,19 @@ static DisplayOpenGLView *instance = nil;
     return;
   }
 
-  int border_x_offset = 0;
-  int border_y_offset = 0;
-  if( settings_current.full_screen ) {
-    /* how much of the top and bottom borders should be eliminated? */
-    NSRect rect = [self bounds];
-    float width_adjustment = 0.0;
-
-    border_x_offset =
-      get_offset( rect.size.width, rect.size.height,
-                  screenTex[currentScreenTex].image_width,
-                  screenTex[currentScreenTex].image_height,
-                  &width_adjustment );
-    border_y_offset = width_adjustment;
-  }
+  /* Letterbox the emulated 4:3 image inside the view's current bounds.
+     In windowed mode the window's contentAspectRatio constraint keeps
+     the view 4:3 and get_offset returns zero margins (no-op). In any
+     fullscreen mode the view fills the display and get_offset produces
+     pillarbox or letterbox margins as appropriate. */
+  NSRect rect = [self bounds];
+  float width_adjustment = 0.0;
+  int border_x_offset =
+    get_offset( rect.size.width, rect.size.height,
+                screenTex[currentScreenTex].image_width,
+                screenTex[currentScreenTex].image_height,
+                &width_adjustment );
+  int border_y_offset = width_adjustment;
 
   /* Bind, update and draw new image */
   glBindTexture( GL_TEXTURE_RECTANGLE_ARB, screenTexId[currentScreenTex] );

--- a/fusepb/views/DisplayOpenGLView.m
+++ b/fusepb/views/DisplayOpenGLView.m
@@ -345,6 +345,13 @@ static DisplayOpenGLView *instance = nil;
   /* keep the window in the standard aspect ratio if the user resizes */
   [[self window] setContentAspectRatio:NSMakeSize(4.0,3.0)];
 
+  /* Opt into AppKit native fullscreen so the green traffic-light
+     button acts as a fullscreen toggle (the standard arrows icon)
+     rather than a zoom. */
+  [[self window] setCollectionBehavior:
+    [[self window] collectionBehavior] |
+    NSWindowCollectionBehaviorFullScreenPrimary];
+
   view_lock = [[NSLock alloc] init];
 
   CVReturn            error = kCVReturnSuccess;

--- a/fusepb/views/DisplayOpenGLView.m
+++ b/fusepb/views/DisplayOpenGLView.m
@@ -1284,14 +1284,12 @@ static DisplayOpenGLView *instance = nil;
 
 -(BOOL) windowShouldClose:(id)window
 {
-  if( cocoaui_confirm( "Exit Fuse?" ) ) {
-    int error = [self checkMediaChanged];
-    if( error ) return NO;
-
-    [self displayLinkStop];
-
-    return YES;
-  }
+  /* Funnel the red-button / Cmd+W close through the same exit path as Cmd+Q
+     so the "Exit Fuse?" confirm and the unsaved-media check live in one
+     place (FuseController -applicationShouldTerminate:). Returning NO lets
+     terminate: take over: if the user confirms, AppKit closes every window
+     itself; if the user cancels, the window stays open. */
+  [NSApp terminate:self];
   return NO;
 }
 

--- a/fusepb/views/DisplayOpenGLView.m
+++ b/fusepb/views/DisplayOpenGLView.m
@@ -360,6 +360,16 @@ static DisplayOpenGLView *instance = nil;
   [proxy_emulator keyboardReleaseAll];
 }
 
+- (void)windowDidExitFullScreen:(NSNotification *)notification
+{
+  /* Release the emulator's mouse grab on fullscreen exit so a user who
+     entered fullscreen with the cursor grabbed regains it. The entry side
+     is deliberately not symmetric: auto-grabbing would hide the cursor
+     and block the menu-bar-on-hover reveal that exposes Open, Preferences,
+     and the rest of the menu in fullscreen. */
+  if( ui_mouse_grabbed ) ui_mouse_grabbed = ui_mouse_release( 0 );
+}
+
 -(void) loadPicture: (NSString *) name
                       greenTex:(Texture*) greenTexture
                       redTex:(Texture*) redTexture

--- a/fusepb/views/DisplayOpenGLView.m
+++ b/fusepb/views/DisplayOpenGLView.m
@@ -1433,6 +1433,13 @@ static DisplayOpenGLView *instance = nil;
 - (void)pinAsChildOf:(NSWindow *)parent
 {
   if( !parent || parent == self ) return;
+  /* Without FullScreenAuxiliary, adding self as a child of a fullscreen
+     parent forces AppKit to exit fullscreen so the two can coexist on
+     the regular desktop. With it, both windows share the parent's
+     fullscreen Space. Harmless when the parent is windowed. */
+  [self setCollectionBehavior:
+    [self collectionBehavior] |
+    NSWindowCollectionBehaviorFullScreenAuxiliary];
   NSWindow *currentParent = [self parentWindow];
   if( currentParent == parent ) return;
   if( currentParent ) {

--- a/fusepb/views/DisplayOpenGLView.m
+++ b/fusepb/views/DisplayOpenGLView.m
@@ -1207,16 +1207,6 @@ static DisplayOpenGLView *instance = nil;
 
 -(void) keyDown:(NSEvent *)theEvent
 {
-  if( settings_current.full_screen ) {
-    unichar c = [[theEvent charactersIgnoringModifiers] characterAtIndex:0];
-    switch (c) {
-    /* [Esc] exits fullScreen mode */
-    case 27:
-      [self fullscreen:nil];
-      return;
-      break;
-    }
-  }
   [proxy_emulator keyDown:theEvent];
 }
 

--- a/fusepb/views/DisplayOpenGLView.m
+++ b/fusepb/views/DisplayOpenGLView.m
@@ -134,51 +134,6 @@ static DisplayOpenGLView *instance = nil;
   return instance;
 }
 
--(IBAction) fullscreen:(id)sender
-{
-  /* don't want to get a callback to display the screen while we are
-   * fiddling with the window to draw into!
-   */
-  [self displayLinkStop];
-
-  if( settings_current.full_screen ) {
-    /* we need to go back to non-full screen */
-    [fullscreenWindow close];
-    [windowedWindow setContentView: self];
-    [windowedWindow makeKeyAndOrderFront: self];
-    [windowedWindow makeFirstResponder: self];
-    settings_current.full_screen = 0;
-    if( ui_mouse_grabbed ) ui_mouse_grabbed = ui_mouse_release( 0 );
-  } else {
-    unsigned int windowStyle;
-    NSRect       contentRect;
-
-    windowedWindow = [self window];
-    windowStyle    = NSBorderlessWindowMask;
-    contentRect    = [[NSScreen mainScreen] frame];
-    fullscreenWindow = [[NSWindow alloc] initWithContentRect:contentRect
-                                         styleMask: windowStyle
-                                         backing:NSBackingStoreBuffered
-                                         defer: NO];
-    if( fullscreenWindow != nil ) {
-      settings_current.full_screen = 1;
-      [fullscreenWindow setTitle: @"Fuse"];
-      [fullscreenWindow setReleasedWhenClosed: YES];
-      [fullscreenWindow setContentView: self];
-      [fullscreenWindow makeKeyAndOrderFront:self ];
-      [fullscreenWindow setLevel: NSScreenSaverWindowLevel - 1];
-      [fullscreenWindow makeFirstResponder:self];
-      if( !ui_mouse_grabbed ) ui_mouse_grabbed = ui_mouse_grab( 0 );
-    }
-  }
-
-  [self displayLinkStart];
-
-  [view_lock lock];
-  statusbar_updated = YES;
-  [view_lock unlock];
-}
-
 -(IBAction) zoom:(id)sender
 {
   NSSize size;
@@ -876,11 +831,6 @@ static DisplayOpenGLView *instance = nil;
 -(void) settingsResetDefaults
 {
   [proxy_emulator settingsResetDefaults];
-}
-
--(void) fullscreen
-{
-  [proxy_emulator fullscreen];
 }
 
 -(void) joystickToggleKeyboard

--- a/fusepb/xibs/MainMenu.xib
+++ b/fusepb/xibs/MainMenu.xib
@@ -694,9 +694,9 @@
                                     <action selector="performMiniaturize:" target="-1" id="932"/>
                                 </connections>
                             </menuItem>
-                            <menuItem title="Fullscreen" keyEquivalent="f" id="461">
+                            <menuItem title="Enter Full Screen" keyEquivalent="f" id="461">
                                 <connections>
-                                    <action selector="fullscreen:" target="879" id="883"/>
+                                    <action selector="toggleFullScreen:" target="877" id="883"/>
                                 </connections>
                             </menuItem>
                         </items>

--- a/ui/cocoa/cocoadisplay.m
+++ b/ui/cocoa/cocoadisplay.m
@@ -244,20 +244,22 @@ cocoadisplay_resize_window( void )
 {
   /* Startup applies the saved scaler before the first rendered frame; let
      AppKit keep the restored window frame until emulation is visibly running. */
-  if( !display_ui_initialised || !window_resize_enabled ||
-      settings_current.full_screen ) return;
+  if( !display_ui_initialised || !window_resize_enabled ) return;
 
   float factor = scaler_get_scaling_factor( current_scaler );
   NSSize size = NSMakeSize( image_width * factor, image_height * factor );
 
   dispatch_async( dispatch_get_main_queue(), ^{
-    /* Re-check after the hop in case the user entered fullscreen between
-       enqueue and execute. */
-    if( settings_current.full_screen ) return;
+    NSWindow *win = [[DisplayOpenGLView instance] window];
+    /* AppKit's fullscreen Space owns the window frame; application code
+       cannot resize a fullscreen window. The pre-dispatch check was
+       previously a worker-thread-safe read of a mirrored flag; the
+       authoritative state lives in the window's styleMask, which must be
+       read on main. */
+    if( ( [win styleMask] & NSWindowStyleMaskFullScreen ) != 0 ) return;
 
     /* Preserve the window's perceived centre; setContentSize: would anchor
        the top-left and drift the centre across repeated scaler changes. */
-    NSWindow *win = [[DisplayOpenGLView instance] window];
     NSRect old = [win frame];
     NSRect frame = [win frameRectForContentRect:
                             NSMakeRect( 0, 0, size.width, size.height )];

--- a/ui/cocoa/cocoaerror.m
+++ b/ui/cocoa/cocoaerror.m
@@ -37,7 +37,6 @@
 
 #include "fuse.h"
 #include "ui/ui.h"
-#include "settings.h"
 
 static int
 aqua_verror( ui_error_level severity, const char *message )
@@ -66,8 +65,5 @@ aqua_verror( ui_error_level severity, const char *message )
 int
 ui_error_specific( ui_error_level severity, const char *message )
 {
-  if ( !settings_current.full_screen ) {
-    return aqua_verror( severity, message );
-  }
-  return 0;
+  return aqua_verror( severity, message );
 }


### PR DESCRIPTION
### Problems solved

1. `Cmd+F` entered fullscreen via the custom borderless-window path, but every keypress inside it produced a UI beep and was otherwise ignored.
2. The green traffic-light button entered a different fullscreen mode than `Cmd+F`: it used AppKit's native transition and never set `settings_current.full_screen`, so the renderer skipped letterboxing and the emulated display was stretched instead of pillarboxed.
3. The menu actions (Open, Save As, etc.) were silently disabled in fullscreen, requiring the user to exit fullscreen to use them.
4. Error alerts from the emulator core (tape errors, disk read failures, network failures) were suppressed in fullscreen, potentially leaving the user with a broken emulator and no indication why.
5. Esc was intercepted as "exit fullscreen" rather than forwarded to the Spectrum keyboard — burning `Caps Shift+1` (EDIT) and blocking mouse-grab release.
6. `Cmd+Q` invoked `performClose:` on the key window instead of `NSApp terminate:`, so the exit-confirm and unsaved-media check could be bypassed from fullscreen.

### Known issues

NSOpenPanel / NSSavePanel (e.g. `Cmd+O` to open a file) are slow to appear in fullscreen (~3–5 s first open vs ~0.5 s windowed). The bottleneck is inside AppKit's powerbox/Space negotiation. This path was previously unreachable from fullscreen, so it is not a regression; needs a separate fix.
