### PR TITLE
Open FDI disk images from Finder

### DIFF
--- a/fusepb/Info-FuseX.plist
+++ b/fusepb/Info-FuseX.plist
@@ -60,6 +60,23 @@
 		<dict>
 			<key>CFBundleTypeExtensions</key>
 			<array>
+				<string>fdi</string>
+				<string>FDI</string>
+			</array>
+			<key>CFBundleTypeIconFile</key>
+			<string>blank</string>
+			<key>CFBundleTypeName</key>
+			<string>ZX Spectrum Disk Image</string>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>net.sourceforge.projects.fuse-emulator.fdi</string>
+			</array>
+		</dict>
+		<dict>
+			<key>CFBundleTypeExtensions</key>
+			<array>
 				<string>rzx</string>
 				<string>RZX</string>
 			</array>
@@ -716,6 +733,25 @@
 				<key>public.filename-extension</key>
 				<array>
 					<string>dsk</string>
+				</array>
+			</dict>
+		</dict>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>net.sourceforge.projects.fuse-emulator.MassStorage</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>ZX Spectrum FDI Disk Image</string>
+			<key>UTTypeIconFile</key>
+			<string>blank</string>
+			<key>UTTypeIdentifier</key>
+			<string>net.sourceforge.projects.fuse-emulator.fdi</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>fdi</string>
 				</array>
 			</dict>
 		</dict>

--- a/fusepb/controllers/FuseController.m
+++ b/fusepb/controllers/FuseController.m
@@ -2679,6 +2679,7 @@ save_as_exit:
       break;
 
     case LIBSPECTRUM_CLASS_DISK_TRDOS:
+    case LIBSPECTRUM_CLASS_DISK_GENERIC:
       settings_current.betadisk_file = strdup( fsrep );
       break;
 


### PR DESCRIPTION
FuseX already supports FDI images, but the only way to actually load one is **File → Open**. Any other entry point — double-clicking in Finder, dropping onto the app icon, or `open -a FuseX foo.fdi` from a shell against a fresh launch — silently drops the file.

Declare the .fdi extension in Info-FuseX.plist so Launch Services routes it to FuseX, and add the `LIBSPECTRUM_CLASS_DISK_GENERIC` case (FDI's class) to the cold-launch openFile: switch. Without the latter the file path is silently dropped on cold launch and setup_start_files has nothing to autoload.

`GENERIC` routes to settings_current.betadisk_file, matching the fallback in fuse.c's `parse_nonoption_args` and the most common real-world use of FDI (Beta 128 / TR-DOS).