### PR TITLE
Fix border rendering timings

### DIFF
--- a/display.c
+++ b/display.c
@@ -102,9 +102,12 @@ static int display_redraw_all;
 /* The last point at which we updated the screen display */
 static int critical_region_x = 0, critical_region_y = 0;
 
-/* The border colour changes which have occurred in this frame */
+/* The border colour changes which have occurred in this frame.
+   `t` is the T-state offset within the scanline at which the change becomes
+   visible (post end-of-OUT alignment), measured from the T-state where this
+   line's display column 0 begins. Range 0..DISPLAY_TSTATES_PER_LINE_VISIBLE. */
 struct border_change_t {
-  int x, y;
+  int t, y;
   int colour;
 };
 
@@ -112,7 +115,7 @@ display_dirty_fn display_dirty;
 display_write_if_dirty_fn display_write_if_dirty;
 
 static struct border_change_t border_change_end_sentinel =
-  { DISPLAY_SCREEN_WIDTH_COLS, DISPLAY_SCREEN_HEIGHT - 1, 0 };
+  { DISPLAY_TSTATES_PER_LINE_VISIBLE, DISPLAY_SCREEN_HEIGHT - 1, 0 };
 
 /* The current border colour */
 int current_border[ DISPLAY_SCREEN_HEIGHT ][ DISPLAY_SCREEN_WIDTH_COLS ];
@@ -139,23 +142,20 @@ alloc_change(void)
   return border_changes + border_changes_last++; 
 }
 
-static int
+static void
 add_border_sentinel( void )
 {
   struct border_change_t *sentinel = alloc_change();
 
-  sentinel->x = sentinel->y = 0;
+  sentinel->t = sentinel->y = 0;
   sentinel->colour = scld_last_dec.name.hires ?
                             display_hires_border : display_lores_border;
-
-  return 0;
 }
 
 int
 display_init( int *argc, char ***argv )
 {
   int i, j, k, x, y;
-  int error;
 
   if(ui_init(argc, argv))
     return 1;
@@ -196,7 +196,7 @@ display_init( int *argc, char ***argv )
     libspectrum_free( border_changes );
   }
   border_changes = NULL;
-  error = add_border_sentinel(); if( error ) return error;
+  add_border_sentinel();
   display_last_border = scld_last_dec.name.hires ?
                             display_hires_border : display_lores_border;
 
@@ -749,26 +749,29 @@ display_get_attr( int x, int y,
 static void
 push_border_change( int colour )
 {
-  /* OUT (#FE) writes the border colour during the I/O cycle of the OUT
-     instruction, but on entry here `tstates` is the value at the moment the
-     port write hook fires, three T-states before the instruction retires
-     (contend_port_late adds 2, then the trailing tstates++). Align the
-     recorded T-state with end-of-instruction so that mid-scanline border
-     transitions land where the beam is when the OUT completes. */
-  int beam_x, beam_y;
+  /* OUT (#FE) is an 11-T-state instruction (Z80 OUT (n),A: 4 M1 + 3 operand
+     + 4 I/O cycle); the ULA reads the new border value from the data bus
+     during the I/O cycle. On entry here, `tstates` already reflects
+     ula_contend_port_early and sits inside that cycle; +2 places the
+     recorded transition where the new colour becomes visible on the beam. */
+  libspectrum_dword t_event = tstates + 2;
+  int beam_y, t_in_line;
   struct border_change_t *change;
 
-  get_beam_position( tstates + 3, &beam_x, &beam_y );
-
-  if( beam_y >= DISPLAY_SCREEN_HEIGHT ) return;
-
-  if( beam_x < 0 ) beam_x = 0;
-  if( beam_x > DISPLAY_SCREEN_WIDTH_COLS ) beam_x = DISPLAY_SCREEN_WIDTH_COLS;
-  if( beam_y < 0 ) beam_y = 0;
+  if( t_event < machine_current->line_times[ 0 ] ) {
+    beam_y = 0;
+    t_in_line = 0;
+  } else {
+    beam_y = ( t_event - machine_current->line_times[ 0 ] ) /
+             machine_current->timings.tstates_per_line;
+    if( beam_y >= DISPLAY_SCREEN_HEIGHT ) return;
+    t_in_line = t_event - machine_current->line_times[ beam_y ];
+    if( t_in_line > DISPLAY_TSTATES_PER_LINE_VISIBLE )
+      t_in_line = DISPLAY_TSTATES_PER_LINE_VISIBLE;
+  }
 
   change = alloc_change();
-
-  change->x = beam_x;
+  change->t = t_in_line;
   change->y = beam_y;
   change->colour = colour;
 }
@@ -806,117 +809,131 @@ display_set_hires_border( int colour )
   check_border_change();
 }
 
+/* Per-line border pixel buffer. Populated from the change list, then flushed
+   column-by-column. Sized for the widest display (Timex = 16 px/col). */
+static int border_pixel_buf[ DISPLAY_SCREEN_WIDTH ];
+
+/* Plot the accumulated border_pixel_buf for row y, column-by-column. The
+   buffer holds one colour per pixel; for each column we detect whether all
+   pixels are identical (solid border, the common case) or there is exactly
+   one mid-column transition (the OUT spacing guarantees at most one per
+   4-T-state column). The transition is emitted via plot8's bitmap form. */
 static void
-set_border( int y, int start, int end, int colour )
+flush_border_line( int y )
 {
-  libspectrum_dword chunk_detail = colour << 11;
-  int index = start + y * DISPLAY_SCREEN_WIDTH_COLS;
+  const int pix_per_col = machine_current->timex ? 16 : 8;
+  const int pix_per_bit = pix_per_col / 8;
+  /* On paper rows, skip the middle columns: the paper rendering path owns
+     display_last_screen for those columns and would be overwritten otherwise. */
+  const int paper_row = ( y >= DISPLAY_BORDER_HEIGHT &&
+                          y <  DISPLAY_BORDER_HEIGHT + DISPLAY_HEIGHT );
+  const int paper_col_start = DISPLAY_BORDER_WIDTH_COLS;
+  const int paper_col_end = DISPLAY_BORDER_WIDTH_COLS + DISPLAY_WIDTH_COLS;
+  int c;
 
-  for( ; start < end; start++ ) {
-    /* Draw it if it is different to what was there last time - we know that
-    data and mode will have been the same */
-    if( display_last_screen[ index ] != chunk_detail ) {
-      uidisplay_plot8( start, y, 0x00, 0, colour );
+  for( c = 0; c < DISPLAY_SCREEN_WIDTH_COLS; c++ ) {
+    int pix_start, colour_left, colour_right, transition_pix, p, index;
+    libspectrum_dword chunk_detail;
+    libspectrum_byte data, ink, paper;
 
-      /* Update last display record */
-      display_last_screen[ index ] = chunk_detail;
+    if( paper_row && c >= paper_col_start && c < paper_col_end ) continue;
 
-      /* And now mark it dirty */
-      display_is_dirty[y] |= ( (libspectrum_qword)1 << start );
+    pix_start = c * pix_per_col;
+    colour_left = border_pixel_buf[ pix_start ];
+    colour_right = colour_left;
+    transition_pix = -1;
+
+    for( p = 1; p < pix_per_col; p++ ) {
+      if( border_pixel_buf[ pix_start + p ] != colour_right ) {
+        /* OUT (#FE) instructions are at least 11 T-states apart, so a single
+           4-T-state column cannot hold two transitions. */
+        if( transition_pix >= 0 ) break;
+        transition_pix = p;
+        colour_right = border_pixel_buf[ pix_start + p ];
+      }
     }
-    index++;
-  }
-}
 
-static void
-border_change_write( int y, int start, int end, int colour )
-{
-  if(   y <  DISPLAY_BORDER_HEIGHT                    ||
-      ( y >= DISPLAY_BORDER_HEIGHT + DISPLAY_HEIGHT )    ) {
-
-    /* Top and bottom borders */
-    set_border( y, start, end, colour );
-
-    return;
-  }
-
-  /* Left border */
-  if( start < DISPLAY_BORDER_WIDTH_COLS ) {
-
-    int left_end =
-      end > DISPLAY_BORDER_WIDTH_COLS ? DISPLAY_BORDER_WIDTH_COLS : end;
-
-    set_border( y, start, left_end, colour );
-  }
-
-  /* Right border */
-  if( end > DISPLAY_BORDER_WIDTH_COLS + DISPLAY_WIDTH_COLS ) {
-
-    if( start < DISPLAY_BORDER_WIDTH_COLS + DISPLAY_WIDTH_COLS )
-      start = DISPLAY_BORDER_WIDTH_COLS + DISPLAY_WIDTH_COLS;
-
-    set_border( y, start, end, colour );
-  }
-}
-
-static void
-border_change_line_part( int y, int start, int end, int colour )
-{
-  border_change_write( y, start, end, colour );
-}
-
-static void
-border_change_line( int y, int colour )
-{
-  border_change_write( y, 0, DISPLAY_SCREEN_WIDTH_COLS, colour );
-}
-
-static void
-do_border_change( struct border_change_t *first,
-		  struct border_change_t *second )
-{
-  if( first->x ) {
-    if( first->x != DISPLAY_SCREEN_WIDTH_COLS )
-      border_change_line_part( first->y, first->x, DISPLAY_SCREEN_WIDTH_COLS,
-			       first->colour );
-    /* Don't extend region past the end of the screen */
-    if( first->y < DISPLAY_SCREEN_HEIGHT - 1 ) first->y++;
-  }
-
-  for( ; first->y < second->y; first->y++ ) {
-    border_change_line( first->y, first->colour );
-  }
-
-  if( second->x ) {
-    if( second->x == DISPLAY_SCREEN_WIDTH_COLS ) {
-      border_change_line( first->y, first->colour );
+    if( transition_pix < 0 ) {
+      chunk_detail = (libspectrum_dword) colour_left << 11;
+      data = 0x00;
+      ink = 0;
+      paper = colour_left;
     } else {
-      border_change_line_part( first->y, 0, second->x, first->colour );
+      /* In plot8's data byte, bit (7-i) covers pixel i (Timex doubles each bit
+         to cover 2 hires pixels). Clear bits left of the transition (paper =
+         colour_left), set bits at or right of it (ink = colour_right). */
+      int transition_bit = transition_pix / pix_per_bit;
+      data = (libspectrum_byte) ( ( 1 << ( 8 - transition_bit ) ) - 1 );
+      ink = colour_right;
+      paper = colour_left;
+      /* Pack the chunk_detail in the same (attr << 8) | bitmap layout the
+         Sinclair paper renderer uses, so display_getpixel, screenshot, and
+         movie capture decode the partial-column cell correctly. attr packs
+         ink=colour_right (bits 0-2) and paper=colour_left (bits 3-5); bits
+         6-7 stay clear so display_parse_attr treats bright and flash as 0. */
+      chunk_detail = ( (libspectrum_dword) ( ( colour_left << 3 ) | colour_right ) << 8 )
+                   |   (libspectrum_dword) data;
+    }
+
+    index = c + y * DISPLAY_SCREEN_WIDTH_COLS;
+    if( display_last_screen[ index ] != chunk_detail ) {
+      uidisplay_plot8( c, y, data, ink, paper );
+      display_last_screen[ index ] = chunk_detail;
+      display_is_dirty[ y ] |= ( (libspectrum_qword)1 << c );
     }
   }
 }
 
 /* Take account of all the border colour changes which happened in this
-   frame */
+   frame. Between each consecutive pair of changes, the swept region is
+   painted with the first change's colour. The pixel buffer accumulates an
+   entire scanline before being flushed so that mid-column transitions can be
+   composited correctly. */
 static void
 update_border( void )
 {
-  int pos;
-  int error;
+  const int pix_per_col = machine_current->timex ? 16 : 8;
+  const int pix_per_tstate = pix_per_col / 4;
+  const int line_pixels = DISPLAY_SCREEN_WIDTH_COLS * pix_per_col;
+  struct border_change_t *end_sentinel;
+  int cursor_y = 0;
+  int cursor_pix = 0;
+  int i;
 
   /* Put the final sentinel onto the list */
-  struct border_change_t *end_sentinel = alloc_change();
-
+  end_sentinel = alloc_change();
   memcpy( end_sentinel, &border_change_end_sentinel,
           sizeof( struct border_change_t ) );
 
-  for( pos = 0; pos < border_changes_last-1; pos++ ) {
-    do_border_change( border_changes+pos, border_changes+pos+1 );
+  for( i = 0; i < border_changes_last - 1; i++ ) {
+    struct border_change_t *first = border_changes + i;
+    struct border_change_t *second = border_changes + i + 1;
+    int target_y = second->y;
+    int target_pix = second->t * pix_per_tstate;
+    int colour = first->colour;
+    int p;
+
+    if( target_pix > line_pixels ) target_pix = line_pixels;
+
+    while( cursor_y < target_y ) {
+      for( p = cursor_pix; p < line_pixels; p++ )
+        border_pixel_buf[ p ] = colour;
+      flush_border_line( cursor_y );
+      cursor_y++;
+      cursor_pix = 0;
+    }
+    if( target_pix > cursor_pix ) {
+      for( p = cursor_pix; p < target_pix; p++ )
+        border_pixel_buf[ p ] = colour;
+      cursor_pix = target_pix;
+    }
   }
 
-  border_changes_last = 0;
+  /* Flush the line the cursor finished on (always reached via the end sentinel) */
+  flush_border_line( cursor_y );
 
-  error = add_border_sentinel(); if( error ) return;
+  border_changes_last = 0;
+  add_border_sentinel();
 }
 
 /* Send the updated screen to the UI-specific code */

--- a/display.c
+++ b/display.c
@@ -637,18 +637,18 @@ copy_critical_region( int beam_x, int beam_y )
 }
 
 static inline void
-get_beam_position( int *x, int *y )
+get_beam_position( libspectrum_dword t, int *x, int *y )
 {
-  if( tstates < machine_current->line_times[ 0 ] ) {
+  if( t < machine_current->line_times[ 0 ] ) {
     *x = *y = -1;
     return;
   }
 
-  *y = ( tstates - machine_current->line_times[ 0 ] ) /
+  *y = ( t - machine_current->line_times[ 0 ] ) /
     machine_current->timings.tstates_per_line;
 
   if( *y >= 0 && *y <= DISPLAY_SCREEN_HEIGHT )
-    *x = ( tstates - machine_current->line_times[ *y ] ) / 4;
+    *x = ( t - machine_current->line_times[ *y ] ) / 4;
   else *x = 0;
 }
 
@@ -657,7 +657,7 @@ update_critical_internal( int x, int y )
 {
   int beam_x, beam_y;
 
-  get_beam_position( &beam_x, &beam_y );
+  get_beam_position( tstates, &beam_x, &beam_y );
 
   beam_x -= DISPLAY_BORDER_WIDTH_COLS;
   beam_y -= DISPLAY_BORDER_HEIGHT;
@@ -749,10 +749,16 @@ display_get_attr( int x, int y,
 static void
 push_border_change( int colour )
 {
+  /* OUT (#FE) writes the border colour during the I/O cycle of the OUT
+     instruction, but on entry here `tstates` is the value at the moment the
+     port write hook fires, three T-states before the instruction retires
+     (contend_port_late adds 2, then the trailing tstates++). Align the
+     recorded T-state with end-of-instruction so that mid-scanline border
+     transitions land where the beam is when the OUT completes. */
   int beam_x, beam_y;
   struct border_change_t *change;
 
-  get_beam_position( &beam_x, &beam_y );
+  get_beam_position( tstates + 3, &beam_x, &beam_y );
 
   if( beam_y >= DISPLAY_SCREEN_HEIGHT ) return;
 

--- a/display.h
+++ b/display.h
@@ -57,6 +57,9 @@
 /* And the width in columns */
 #define DISPLAY_SCREEN_WIDTH_COLS ( DISPLAY_WIDTH_COLS + 2 * DISPLAY_BORDER_WIDTH_COLS )
 
+/* T-states the beam takes to cross the visible scanline (one column = 4 T-states) */
+#define DISPLAY_TSTATES_PER_LINE_VISIBLE ( DISPLAY_SCREEN_WIDTH_COLS * 4 )
+
 /* The aspect ratio corrected display width */
 #define DISPLAY_ASPECT_WIDTH  ( DISPLAY_SCREEN_WIDTH / 2 )
 


### PR DESCRIPTION
Border effects are rendered incorrectly in FuseX. For example, in the following two demos:
1. [Across The Edge by deMarche](https://zxaaa.net/view_demo.php?id=9284)
2. [Rage](https://zxaaa.net/view_demo.php?id=2632)

Note, they use Pentagon 128K timings, so should be tested there.

The first commit fixes the horizontal offset of the border colors (the defect is visible in the very beginning of the first demo). The second commit fixes rendering of non-horizontal patterns on the border (e.g. the wavy pattern in the first demo).