### PR TITLE
Re-enable WAV loading after WAV-gate rename

### DIFF
--- a/fusepb/config.h
+++ b/fusepb/config.h
@@ -46,8 +46,8 @@
 /* Define to 1 if you have the `bz2' library (-lbz2). */
 #define HAVE_LIBBZ2 1
 
-/* Defined if we've got audiofile */
-#define HAVE_LIB_AUDIOFILE 1
+/* Defined if a WAV backend is available */
+#define HAVE_WAV_BACKEND 1
 
 /* Defined if we've got glib */
 /* #undef HAVE_LIB_GLIB */


### PR DESCRIPTION
https://github.com/speccytools/libspectrum/commit/68e5bbc ("Add native macOS WAV support") renamed the WAV feature gate in tape.c from `HAVE_LIB_AUDIOFILE` to `HAVE_WAV_BACKEND`. https://github.com/speccytools/fusex/pull/36 didn't update fusepb/config.h, so the WAV branch compiled out and opening a WAV tape produced

> libspectrum: libspectrum_tape_read: format not supported without a WAV backend

Define `HAVE_WAV_BACKEND` so tape.c calls `libspectrum_wav_read()`, which dispatches to wav_macos.c (already in the Xcode Sources phase, with AudioToolbox.framework already linked).

`HAVE_LIB_AUDIOFILE` has no remaining consumers in the compiled tree, so drop it.