### PR TITLE
Decouple Tape Browser updates from emulation pause

### DIFF
--- a/fusepb/controllers/TapeBrowserController.h
+++ b/fusepb/controllers/TapeBrowserController.h
@@ -45,6 +45,8 @@
 - (void)addObjectToInfoContents:(NSDictionary*)info;
 - (void)setTapeIndex:(NSNumber*)index;
 - (void)setInitialising:(NSNumber*)value;
+- (void)setDocumentEditedFlag:(NSNumber*)flag;
+- (void)populateFromTape;
 
 - (void)tableViewSelectionDidChange:(NSNotification *)aNotification;
 

--- a/fusepb/controllers/TapeBrowserController.m
+++ b/fusepb/controllers/TapeBrowserController.m
@@ -116,7 +116,9 @@ static TapeBrowserController *singleton = nil;
 
 - (void)setTapeIndex:(NSNumber*)index
 {
-  [tapeController setSelectionIndex:[index unsignedIntValue]];
+  NSUInteger idx = [index unsignedIntValue];
+  [tapeController setSelectionIndex:idx];
+  [tapeBrowser scrollRowToVisible:(NSInteger)idx];
 }
 
 - (void)setInitialising:(NSNumber*)value

--- a/fusepb/controllers/TapeBrowserController.m
+++ b/fusepb/controllers/TapeBrowserController.m
@@ -26,10 +26,10 @@
 #include <config.h>
 
 #import "DisplayOpenGLView.h"
+#import "Emulator.h"
 #import "TapeBrowserController.h"
 
 #include "tape.h"
-#include "fuse.h"
 
 static void
 add_block_details( libspectrum_tape_block *block, void *user_data );
@@ -93,13 +93,9 @@ static TapeBrowserController *singleton = nil;
 
 - (void)showWindow:(id)sender
 {
-  [[DisplayOpenGLView instance] pause];
-  
   [super showWindow:sender];
 
   [[DisplayOpenGLView instance] tapeWindowInitialise];
-
-  [[DisplayOpenGLView instance] unpause];
 }
 
 - (void)clearContents
@@ -126,6 +122,36 @@ static TapeBrowserController *singleton = nil;
 - (void)setInitialising:(NSNumber*)value
 {
   initialising = [value boolValue];
+}
+
+- (void)setDocumentEditedFlag:(NSNumber*)flag
+{
+  [[self window] setDocumentEdited:[flag boolValue]];
+}
+
+/* Runs on the emulator thread to serialise the tape_foreach walk with
+   save-trap / RZX block appends. */
+- (void)populateFromTape
+{
+  int current_block;
+
+  [self performSelectorOnMainThread:@selector(clearContents)
+                          withObject:nil
+                       waitUntilDone:NO];
+  [self performSelectorOnMainThread:@selector(setInitialising:)
+                          withObject:@(YES)
+                       waitUntilDone:NO];
+  tape_foreach( add_block_details, self );
+  [self performSelectorOnMainThread:@selector(setInitialising:)
+                          withObject:@(NO)
+                       waitUntilDone:NO];
+
+  current_block = tape_get_current_block();
+  if( current_block >= 0 ) {
+    [self performSelectorOnMainThread:@selector(setTapeIndex:)
+                            withObject:@((unsigned int)current_block)
+                         waitUntilDone:NO];
+  }
 }
 
 @synthesize tapeController;
@@ -324,38 +350,27 @@ int
 ui_tape_browser_update( ui_tape_browser_update_type change,
                         libspectrum_tape_block *block )
 {
-  int error;
   TapeBrowserController* tapeBrowserController;
 
   if( !dialog_created ) return 0;
 
-  fuse_emulation_pause();
-
   tapeBrowserController = [TapeBrowserController singleton];
 
   if( change == UI_TAPE_BROWSER_NEW_TAPE ) {
-    [tapeBrowserController
-          performSelectorOnMainThread:@selector(clearContents)
-          withObject:nil
-          waitUntilDone:NO
-    ];
-
-    [tapeBrowserController
-          performSelectorOnMainThread:@selector(setInitialising:)
-          withObject:@(YES)
-          waitUntilDone:NO
-    ];
-    error = tape_foreach( add_block_details, tapeBrowserController );
-    [tapeBrowserController
-          performSelectorOnMainThread:@selector(setInitialising:)
-          withObject:@(NO)
-          waitUntilDone:NO
-    ];
-    if( error ) return error;
+    NSThread *emulThread = [[Emulator instance] emulatorThread];
+    if( emulThread == nil || [NSThread currentThread] == emulThread ) {
+      [tapeBrowserController populateFromTape];
+    } else {
+      [tapeBrowserController
+            performSelector:@selector(populateFromTape)
+            onThread:emulThread
+            withObject:nil
+            waitUntilDone:NO
+      ];
+    }
   }
 
-  if( change == UI_TAPE_BROWSER_SELECT_BLOCK ||
-    change == UI_TAPE_BROWSER_NEW_TAPE ) {
+  if( change == UI_TAPE_BROWSER_SELECT_BLOCK ) {
     int current_block = tape_get_current_block();
     if(current_block >= 0) {
       [tapeBrowserController
@@ -370,13 +385,11 @@ ui_tape_browser_update( ui_tape_browser_update_type change,
     add_block_details( block, tapeBrowserController );
   }
 
-  if( tape_modified ) {
-    [[tapeBrowserController window] setDocumentEdited:YES];
-  } else {
-    [[tapeBrowserController window] setDocumentEdited:NO];
-  }
-
-  fuse_emulation_unpause();
+  [tapeBrowserController
+        performSelectorOnMainThread:@selector(setDocumentEditedFlag:)
+        withObject:@(tape_modified ? YES : NO)
+        waitUntilDone:NO
+  ];
 
   return 0;
 }

--- a/fusepb/models/Emulator.h
+++ b/fusepb/models/Emulator.h
@@ -85,6 +85,7 @@
 -(int) tapeClose;
 -(void) tapeWindowInitialise;
 -(void) cocoaBreak;
+-(NSThread *) emulatorThread;
 -(void) pause;
 -(void) unpause;
 -(void) reset;

--- a/fusepb/models/Emulator.m
+++ b/fusepb/models/Emulator.m
@@ -385,6 +385,11 @@ static Emulator *instance = nil;
   debugger_mode = DEBUGGER_MODE_HALTED;
 }
 
+-(NSThread *) emulatorThread
+{
+  return emulatorThread;
+}
+
 -(void) pause
 {
   fuse_emulation_pause();


### PR DESCRIPTION
### Problems solved

1. Audible gaps between consecutive blocks that use short pilot tones. For example, some releases by DiggerSoft have turbo blocks with `pilot_length = 1084 T` and a pulse count of mostly 16. That comes to about 5 ms total, and the blocks are meant to play as a single whole.
2. Opening the Tape Browser pauses the emulator for a moment. Noticeable with any tape, and may break loading with some loaders.
3. The Tape Browser viewport doesn't scroll to follow the highlighted current block as playback advances. This is noticeable with tape images that have a large number of short blocks.

### What this PR does

Removes both pause wraps from the Cocoa Tape Browser — the one inside `ui_tape_browser_update` and the one around `TapeBrowserController.showWindow:`. The browser's UI updates already dispatch asynchronously to the main thread, so neither wrap is load-bearing on Cocoa; they're vestiges of the original GTK1 single-threaded design. The previously-synchronous cross-thread `setDocumentEdited:` call becomes a `setDocumentEditedFlag:` main-thread dispatch so the function is thread-correct end-to-end, and the `NEW_TAPE` walk (the only branch that iterates `tape->blocks` directly) is dispatched onto the emulator thread via `performSelector:onThread:` — the same thread where save-trap and RZX block appends fire — so list iteration and mutation are serialised on a single thread.

`setTapeIndex:` now calls `-scrollRowToVisible:` after `-setSelectionIndex:` so the highlighted current block stays visible as playback advances.
