### PR TITLE
Guard qXfer against a missing argument separator

### DIFF
--- a/debugger/gdbserver.c
+++ b/debugger/gdbserver.c
@@ -238,6 +238,10 @@ static void process_xfer(const char *name, char *args)
 {
   const char *mode = args;
   args = strchr(args, ':');
+  if( !args ) {
+    packet_send_message((const uint8_t*)"", 0);
+    return;
+  }
   *args++ = '\0';
   
   if (!strcmp(name, "features") && !strcmp(mode, "read")) {


### PR DESCRIPTION
A `qXfer` query without its third colon (e.g. `qXfer:features:read`) made `process_xfer()` dereference a NULL `strchr` result, crashing the emulator. The fix replies with an empty `$#00` ("unsupported") packet instead.

Repro: launch with `--gdbserver-enable --gdbserver-port=1337`, then send one packet:

```python
import socket
data = b"qXfer:features:read"
pkt  = b"$" + data + b"#%02x" % (sum(data) & 0xff)
s = socket.create_connection(("127.0.0.1", 1337)); s.sendall(pkt)
print(s.recv(64))   # fixed: b'+$#00'  |  unpatched: b'+' then the peer dies
```

Crash signature on unpatched `master`:

```
EXC_BAD_ACCESS / SIGSEGV at 0x0
  process_xfer    gdbserver.c:241   ← *args++ through NULL
  process_query   gdbserver.c:293
  process_packet  gdbserver.c:487
```
