### PR TITLE
Don't abort on malformed RSP m/P/Z/z packets

### DIFF
--- a/debugger/gdbserver.c
+++ b/debugger/gdbserver.c
@@ -437,11 +437,13 @@ uint8_t process_packet()
         case 'm':
         {
             struct action_mem_args_t mem;
-            assert(sscanf(payload, "%zx,%zx", &mem.maddr, &mem.mlen) == 2);
-            if (mem.mlen * SZ * 2 > 0x20000)
-            {
-              puts("Buffer overflow!");
-              exit(-1);
+            if (sscanf(payload, "%zx,%zx", &mem.maddr, &mem.mlen) != 2) {
+                packet_send_message((const uint8_t*)"E01", 3);
+                break;
+            }
+            if (mem.mlen * SZ * 2 > 0x20000) {
+                packet_send_message((const uint8_t*)"E01", 3);
+                break;
             }
           
             if (gdbserver_execute_on_main_thread(action_get_mem, &mem, tmpbuf))
@@ -473,7 +475,10 @@ uint8_t process_packet()
         {
             struct action_register_args_t r;
             r.reg = strtol(payload, NULL, 16);
-            assert('=' == *payload++);
+            if ('=' != *payload++) {
+                packet_send_message((const uint8_t*)"E01", 3);
+                break;
+            }
           
             hex2mem(payload, (void *)&r.value, SZ * 2);
           
@@ -563,7 +568,10 @@ uint8_t process_packet()
         case 'Z':
         {
             size_t type, addr, length;
-            assert(sscanf(payload, "%zx,%zx,%zx", &type, &addr, &length) == 3);
+            if (sscanf(payload, "%zx,%zx,%zx", &type, &addr, &length) != 3) {
+                packet_send_message((const uint8_t*)"E01", 3);
+                break;
+            }
           
             struct action_breakpoint_args_t b;
             b.maddr = addr;
@@ -576,7 +584,10 @@ uint8_t process_packet()
         case 'z':
         {
             size_t type, addr, length;
-            assert(sscanf(payload, "%zx,%zx,%zx", &type, &addr, &length) == 3);
+            if (sscanf(payload, "%zx,%zx,%zx", &type, &addr, &length) != 3) {
+                packet_send_message((const uint8_t*)"E01", 3);
+                break;
+            }
           
             struct action_breakpoint_args_t b;
             b.maddr = addr;


### PR DESCRIPTION
The `m`, `P`, `Z`, and `z` RSP handlers `assert()`ed on a failed field parse (and the `m` handler `exit()`ed on an oversized length). `assert()` is compiled in here (NDEBUG undefined), so a single malformed packet from any client aborted the emulator. The fix replies `E01` and continues, as the `M` handler already does.

Repro: launch with `--gdbserver-enable --gdbserver-port=1337`, then send one short `Z` packet (one field where the handler expects three):

```python
import socket
data = b"Z0"
pkt  = b"$" + data + b"#%02x" % (sum(data) & 0xff)
s = socket.create_connection(("127.0.0.1", 1337)); s.sendall(pkt)
print(s.recv(64))   # fixed: b'+$E01#a6'  |  unpatched: b'+' then the peer dies
```

The same applies to `z0`, `P5` (no `=`), `m` (no fields), and `mFFFFFFFFFFFF,FFFFFFFF` (oversized length) — all abort on unpatched `master` and reply `E01` with the fix.

Crash signature on unpatched `master`:

```
EXC_CRASH / SIGABRT (Abort trap: 6)
  __assert_rtn
  process_packet  gdbserver.c:566   ← assert(sscanf(...) == 3) in the Z handler
  process_network gdbserver.c:641
```
