### PR TITLE
Exit cleanly on --help/--version

### DIFF
--- a/fusepb/models/Emulator.m
+++ b/fusepb/models/Emulator.m
@@ -198,6 +198,10 @@ static Emulator *instance = nil;
   }
   [Emulator endROMScopedAccess:romURLs];
 
+  if( settings_current.show_help || settings_current.show_version ) {
+    exit( 0 );
+  }
+
   [proxy_view setServer:self];
 
   while( !fuse_exiting ) {


### PR DESCRIPTION
`--help` and `--version` print their text and return from `fuse_init` without initialising the emulator. The Cocoa run loop then runs against uninitialised state and crashes. This exits before entering the run loop.

Repro: launch with `--help`, then quit.

```
open -n fusepb/build/Deployment/FuseX.app --args --help
osascript -e 'tell application "FuseX" to quit'
```

Unpatched `master` runs in a broken state and crashes on quit; with the fix the app exits cleanly on launch and never enters the run loop.

Crash signature on unpatched `master`:

```
EXC_BAD_ACCESS / SIGSEGV at 0x0
  libspectrum_tape_clear         tape.c:143
  tape_close                     tape.c:285
  menu_check_media_changed       FuseMenus.m:54
  -[Emulator checkMediaChanged]  Emulator.m:452
```
