### PR TITLE
Don't abort launch on an unreadable open argument

### DIFF
--- a/fusepb/controllers/FuseController.m
+++ b/fusepb/controllers/FuseController.m
@@ -2645,14 +2645,19 @@ save_as_exit:
     [self openFile:fsrep];
     [[DisplayOpenGLView instance] unpause];
   } else {
-    if( utils_read_file( fsrep, &file ) ) fuse_abort();
-
-    if( libspectrum_identify_file( &type, fsrep, file.buffer, file.length ) ) {
-      utils_close_file( &file );
-      fuse_abort();
+    /* AppKit routes stray command-line arguments here on cold launch; an
+       argument that is not a readable, identifiable file must be declined. */
+    if( utils_read_file( fsrep, &file ) ) {
+      fprintf( stderr, "%s: couldn't open `%s'\n", fuse_progname, fsrep );
+      return NO;
     }
 
-    if( libspectrum_identify_class( &lsclass, type ) ) fuse_abort();
+    if( libspectrum_identify_file( &type, fsrep, file.buffer, file.length ) ||
+        libspectrum_identify_class( &lsclass, type ) ) {
+      fprintf( stderr, "%s: couldn't identify `%s'\n", fuse_progname, fsrep );
+      utils_close_file( &file );
+      return NO;
+    }
 
     switch( lsclass ) {
 


### PR DESCRIPTION
On cold launch AppKit routes stray command-line arguments to `application:openFile:`. Before `display_ui_initialised`, an argument that is not a readable, identifiable file called `fuse_abort()`, which dereferences NULL in `startup_manager_run_end` because the startup manager isn't initialised yet. This declines such arguments (`return NO`) instead.

Repro: launch with a stray value-bearing option whose argument AppKit treats as a file to open.

```
open -n fusepb/build/Deployment/FuseX.app --args --gdbserver-enable --machine 48
```

Unpatched `master` crashes during launch (`48` is routed to `openFile:`, fails to read, aborts). With the fix the app declines `48` and launches normally.

Crash signature on unpatched `master`:

```
EXC_BAD_ACCESS / SIGSEGV at 0x8
  startup_manager_run_end                  startup_manager.c:174
  fuse_end                                 fuse.c:982
  fuse_abort                               fuse.c:1002
  -[FuseController application:openFile:]   FuseController.m
  -[NSApplication _doOpenFile:ok:tryTemp:]
  -[NSApplication finishLaunching]
```
