### PR TITLE
Reset the debugger command lexer between commands

### DIFF
--- a/debugger/command.c
+++ b/debugger/command.c
@@ -43,6 +43,7 @@ static char *command_ptr;
 
 int yyparse( void );
 int yywrap( void );
+void debugger_command_lexer_reset( void );
 
 /* Evaluate the debugger command given in 'command' */
 void
@@ -56,7 +57,9 @@ debugger_command_evaluate( const char *command )
 
   /* Start parsing at the start of the given command */
   command_ptr = command_buffer;
-    
+
+  debugger_command_lexer_reset();
+
   /* Parse the command */
   yyparse();
 

--- a/debugger/commandl.l
+++ b/debugger/commandl.l
@@ -161,3 +161,13 @@ end             { BEGIN(INITIAL); return DEBUGGER_END; }
 \n              { return '\n'; }
 
 }
+
+%%
+
+/* Reset the lexer start condition to INITIAL so the next command parses from
+   a clean state, regardless of how the previous one left it. */
+void
+debugger_command_lexer_reset( void )
+{
+  BEGIN( INITIAL );
+}


### PR DESCRIPTION
The flex lexer for the Fuse debugger's command language never reset its start condition between `debugger_command_evaluate()` calls. A command that enters command-state and ends mid-state — e.g. the malformed `commands 1` — leaves the lexer stuck in the exclusive `COMMANDSTATE2`, where every following line is lexed as a single `STRING` token and fails with "syntax error, unexpected STRING" until FuseX restarts. The fix resets the start condition to `INITIAL` at the top of each command. It affects both the gdbserver `monitor` channel and the Cocoa debugger entry box, since both route through `debugger_command_evaluate()`.

Repro in the Cocoa debugger (Machine ▸ Debugger):

1. Submit `commands 1` — errors as malformed with `syntax error, unexpected $end, expecting '\n'` (expected), and wedges the lexer.
2. Submit any valid command, e.g. `step` — fails with `syntax error, unexpected STRING`, and stays broken for every command after.

With the fix, step 2 executes normally.
