### PR TITLE
Wait for emulation before accepting gdbserver clients

### DIFF
--- a/debugger/gdbserver.c
+++ b/debugger/gdbserver.c
@@ -56,6 +56,18 @@ static volatile char gdbserver_trapped = 0;
 static int gdbserver_port = 0;
 static int gdbserver_requested_port = 0;
 static int gdbserver_last_trap_reason = DEBUG_TRAP_REASON_SIGNAL_RECEIVED;
+static volatile int gdbserver_emulating = 0;
+static pthread_mutex_t emulating_mutex;
+static pthread_cond_t emulating_cond;
+
+void gdbserver_note_emulating(void)
+{
+    if (gdbserver_emulating) return;
+    pthread_mutex_lock(&emulating_mutex);
+    gdbserver_emulating = 1;
+    pthread_cond_broadcast(&emulating_cond);
+    pthread_mutex_unlock(&emulating_mutex);
+}
 
 static pthread_t network_thread_id;
 /** Set while tearing the listener down; unblocks gdbserver_execute_on_main_thread and gdbserver_activate_with_reason. */
@@ -681,6 +693,14 @@ static int process_network(int socket)
 
 static void* network_thread(void* arg)
 {
+    pthread_mutex_lock(&emulating_mutex);
+    while (!gdbserver_emulating && !gdbserver_shutting_down &&
+           gdbserver_debugging_enabled)
+    {
+        pthread_cond_wait(&emulating_cond, &emulating_mutex);
+    }
+    pthread_mutex_unlock(&emulating_mutex);
+
     while (gdbserver_debugging_enabled)
     {
         {
@@ -758,9 +778,11 @@ void gdbserver_init()
 {
     pthread_cond_init(&trapped_cond, NULL);
     pthread_cond_init(&response_cond, NULL);
+    pthread_cond_init(&emulating_cond, NULL);
     pthread_mutex_init(&trap_process_mutex, NULL);
     pthread_mutex_init(&network_read_mutex, NULL);
     pthread_mutex_init(&network_write_mutex, NULL);
+    pthread_mutex_init(&emulating_mutex, NULL);
     
     // Initialize packets subsystem
     packets_init();
@@ -887,6 +909,10 @@ void gdbserver_stop()
     pthread_cond_broadcast(&response_cond);
     pthread_cond_broadcast(&trapped_cond);
     pthread_mutex_unlock(&trap_process_mutex);
+
+    pthread_mutex_lock(&emulating_mutex);
+    pthread_cond_broadcast(&emulating_cond);
+    pthread_mutex_unlock(&emulating_mutex);
 
 #ifdef WIN32
     if (gdbserver_client_socket != -1)

--- a/debugger/gdbserver.h
+++ b/debugger/gdbserver.h
@@ -14,6 +14,7 @@ int gdbserver_start( int port );
 void gdbserver_stop();
 int gdbserver_activate();
 int gdbserver_activate_with_reason(int trap_reason);
+void gdbserver_note_emulating(void);
 void gdbserver_refresh_status();
 void gdbserver_schedule_reset(void);
 void gdbserver_schedule_autoboot(void);

--- a/spectrum.c
+++ b/spectrum.c
@@ -27,6 +27,7 @@
 
 #include "compat.h"
 #include "debugger/debugger.h"
+#include "debugger/gdbserver.h"
 #include "display.h"
 #include "event.h"
 #include "keyboard.h"
@@ -314,6 +315,7 @@ spectrum_unattached_port_none( void )
 void
 spectrum_do_frame(void)
 {
+  gdbserver_note_emulating();
   while( !event_frame_end ) {
     z80_do_opcodes();
     event_do_events();
@@ -325,6 +327,7 @@ spectrum_do_frame(void)
 void
 spectrum_do_timer( libspectrum_dword target_tstates )
 {
+  gdbserver_note_emulating();
   event_timer=0;
   event_add( target_tstates + tstates, timer_event );
   while( !event_timer ) {


### PR DESCRIPTION
The gdbserver accepts client connections before the emulation loop starts running. A client that connects in that window and sends the RSP `?` packet hangs: answering `?` requires trapping the emulator, which is only possible once emulation is executing. The connection times out.

Hold the accept loop until emulation is running. The emulation loop signals a condition variable when it starts; the network thread waits on it before accepting clients. `gdbserver_stop` also signals it so teardown never blocks.
